### PR TITLE
Update code according to MeiliSearch v0.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,7 @@ search.start();
 
 ## Compatibility with MeiliSearch
 
-This package is compatible with the following MeiliSearch versions:
-
-- `v0.15.X`
+This package only guarantees the compatibility with the [version v0.15.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.15.0).
 
 ## Development Workflow and Contributing
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ search.start();
 
 This package is compatible with the following MeiliSearch versions:
 
-- `v0.13.X`
+- `v0.15.X`
 
 ## Development Workflow and Contributing
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ export default function instantMeiliSearch(hostUrl, apiKey, options = {}) {
         filters,
       } = params
       const searchInput = {
-        q: this.placeholderSearch && query === '' ? null : query,
+        q: query,
         facetsDistribution: facets.length ? facets : undefined,
         facetFilters: facetFilters,
         attributesToHighlight: this.attributesToHighlight,


### PR DESCRIPTION
⚠️ This PR should not be merged until the MeiliSearch's release v0.15.0 is out and the demo server (https://demos.meilisearch.com) is upgraded to v0.15.0