### PR TITLE
Add repository backlink for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
   ],
   "author": "Clementine Urquizar",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/meilisearch/instant-meilisearch.git"
+  },
   "dependencies": {
     "meilisearch": "^0.15.0"
   },


### PR DESCRIPTION
This should make a repository link appear e.g. on https://www.npmjs.com/package/@meilisearch/instant-meilisearch and make the github link on https://bundlephobia.com/result?p=@meilisearch/instant-meilisearch work.