### PR TITLE
Add error information in console

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -92,23 +92,28 @@ export default function instantMeiliSearch(hostUrl, apiKey, options = {}) {
     },
 
     search: async function (requests) {
-      // Params got from InstantSearch
-      const params = requests[0].params
-      this.pagination = params.page !== undefined // If the pagination widget has been set
-      this.hitsPerPage = params.hitsPerPage || 20 // 20 is the MeiliSearch's default limit value. `hitsPerPage` can be changed with `InsantSearch.configure`.
-      // Gets information from IS and transforms it for MeiliSearch
-      const searchInput = this.transformToMeiliSearchParams(params)
-      const indexUid = requests[0].indexName
-      // Executes the search with MeiliSearch
-      const searchResponse = await this.client
-        .index(indexUid)
-        .search(searchInput.q, searchInput)
-      // Parses the MeiliSearch response and returns it for InstantSearch
-      return this.parseMeiliSearchResponse(
-        indexUid,
-        searchResponse,
-        requests[0].params
-      )
+      try {
+        // Params got from InstantSearch
+        const params = requests[0].params
+        this.pagination = params.page !== undefined // If the pagination widget has been set
+        this.hitsPerPage = params.hitsPerPage || 20 // 20 is the MeiliSearch's default limit value. `hitsPerPage` can be changed with `InsantSearch.configure`.
+        // Gets information from IS and transforms it for MeiliSearch
+        const searchInput = this.transformToMeiliSearchParams(params)
+        const indexUid = requests[0].indexName
+        // Executes the search with MeiliSearch
+        const searchResponse = await this.client
+          .index(indexUid)
+          .search(searchInput.q, searchInput)
+        // Parses the MeiliSearch response and returns it for InstantSearch
+        return await this.parseMeiliSearchResponse(
+          indexUid,
+          searchResponse,
+          requests[0].params
+        )
+      } catch (e) {
+        console.error(e)
+        throw new Error(e)
+      }
     },
   }
 }


### PR DESCRIPTION
Best I could do given that the problem comes from algolia itself: 

<img width="960" alt="Screenshot 2021-01-16 at 23 28 02" src="https://user-images.githubusercontent.com/33010418/104824592-5403d800-5853-11eb-8e53-dfdd5a384cc1.png">


First error shown is our error, second is the unhandled error of algolia. Maybe a more deep dive search could help us find a solution where algolia's unhandled error would not appear. But meanwhile, the user is aware of its errors.

fixes https://github.com/meilisearch/meilisearch-vue/issues/7
fixes #216