### PR TITLE
Changed to named export instead of default export

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,6 +132,14 @@ Once the changes are merged on `master`, you can publish the current draft relea
 
 GitHub Actions will be triggered and push the package to [npm](https://www.npmjs.com/package/@meilisearch/instant-meilisearch).
 
+Once the version is available on npm, please update the instant-meilisearch version used in the different Code-Sandboxes we provide:
+
+- [MeiliSearch + InstantSearch](https://codesandbox.io/s/ms-is-mese9)
+- [MeiliSearch + Vue InstantSearch](https://codesandbox.io/s/ms-vue-is-1d6bi)
+- [MeiliSearch + React InstantSearch](https://codesandbox.io/s/ms-react-is-sh9ud)
+
+If you don't have the access to do it, please request it internally.
+
 <hr>
 
 Thank you again for reading this through, we can not wait to begin to work with you if you made your way through this contributing guide ❤️

--- a/playgrounds/html/public/index.html
+++ b/playgrounds/html/public/index.html
@@ -21,7 +21,7 @@
     <script src="https://cdn.jsdelivr.net/npm/instantsearch.js@4"></script>
     <script>
       // This is due to parcel not accepting globals on html files.
-      instantMeiliSearch = instantMeiliSearch.instantMeiliSearch
+      instantMeiliSearch = instantMeiliSearch.instantMeiliSearch;
       const search = instantsearch({
           indexName: "steam-video-games",
           searchClient: instantMeiliSearch(
@@ -54,4 +54,3 @@
     </script>
   </body>
 </html>
-

--- a/playgrounds/html/public/index.html
+++ b/playgrounds/html/public/index.html
@@ -20,38 +20,37 @@
     <script src="../../../src/index.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/instantsearch.js@4"></script>
     <script>
-      console.log(instantMeiliSearch)
-      instantMeiliSearch = instantMeiliSearch.default
-        const search = instantsearch({
-            indexName: "steam-video-games",
-            searchClient: instantMeiliSearch(
-              "https://demos.meilisearch.com",
-              "dc3fedaf922de8937fdea01f0a7d59557f1fd31832cb8440ce94231cfdde7f25",
-            )
-            });
-            search.addWidgets([
-            instantsearch.widgets.searchBox({
-                container: "#searchbox",
-                placeholder: "Search..",
-            }),
-            instantsearch.widgets.configure({
-              hitsPerPage: 8,
-            }),
-            instantsearch.widgets.hits({
-                container: "#hits",
-                templates: {
-                item: `
-                    <div>
-                    <div class="hit-name">
-                        {{#helpers.highlight}}{ "attribute": "name" }{{/helpers.highlight}}
-                    </div>
-                    </div>
-                `
-                }
-            })
-            ]);
-
-            search.start();
+      // This is due to parcel not accepting globals on html files.
+      instantMeiliSearch = instantMeiliSearch.instantMeiliSearch
+      const search = instantsearch({
+          indexName: "steam-video-games",
+          searchClient: instantMeiliSearch(
+            "https://demos.meilisearch.com",
+            "dc3fedaf922de8937fdea01f0a7d59557f1fd31832cb8440ce94231cfdde7f25",
+          )
+          });
+      search.addWidgets([
+        instantsearch.widgets.searchBox({
+            container: "#searchbox",
+            placeholder: "Search..",
+        }),
+        instantsearch.widgets.configure({
+          hitsPerPage: 8,
+        }),
+        instantsearch.widgets.hits({
+          container: "#hits",
+          templates: {
+          item: `
+              <div>
+              <div class="hit-name">
+                  {{#helpers.highlight}}{ "attribute": "name" }{{/helpers.highlight}}
+              </div>
+              </div>
+          `
+          }
+        })
+      ]);
+      search.start();
     </script>
   </body>
 </html>

--- a/playgrounds/javascript/src/app.js
+++ b/playgrounds/javascript/src/app.js
@@ -1,4 +1,4 @@
-import instantMeiliSearch from '../../../src/index'
+import { instantMeiliSearch } from '../../../src/index'
 
 const search = instantsearch({
   indexName: 'steam-video-games',

--- a/playgrounds/react/src/App.js
+++ b/playgrounds/react/src/App.js
@@ -11,7 +11,7 @@ import {
   Configure
 } from "react-instantsearch-dom";
 import "./App.css";
-import instantMeiliSearch from "./instant-meilisearch.js";
+import { instantMeiliSearch } from "./instant-meilisearch.js";
 
 const searchClient = instantMeiliSearch(
   "https://demos.meilisearch.com",

--- a/playgrounds/vue/src/App.vue
+++ b/playgrounds/vue/src/App.vue
@@ -58,7 +58,7 @@
 
 <script>
 import "instantsearch.css/themes/algolia-min.css";
-import instantMeiliSearch from "../../../src/index.js";
+import { instantMeiliSearch } from "../../../src/index.js";
 
 export default {
   data() {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,7 +10,6 @@ function getOutputFileName(fileName, isProd = false) {
 }
 
 const env = process.env.NODE_ENV || 'development'
-const LIB_NAME = 'instantMeiliSearch'
 const ROOT = resolve(__dirname, '.')
 
 module.exports = [
@@ -18,7 +17,8 @@ module.exports = [
   {
     input: 'src/index.js', // directory to transpilation of typescript
     output: {
-      name: LIB_NAME,
+      name: 'window',
+      extend: true,
       file: getOutputFileName(
         // will add .min. in filename if in production env
         resolve(ROOT, pkg.browser),
@@ -52,7 +52,7 @@ module.exports = [
           resolve(ROOT, pkg.cjs),
           env === 'production'
         ),
-        exports: 'default',
+        exports: 'named',
         format: 'cjs',
         sourcemap: env === 'production', // create sourcemap for error reporting in production mode
       },
@@ -61,7 +61,7 @@ module.exports = [
           resolve(ROOT, pkg.module),
           env === 'production'
         ),
-        exports: 'default',
+        exports: 'named',
         format: 'es',
         sourcemap: env === 'production', // create sourcemap for error reporting in production mode
       },

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import { MeiliSearch } from 'meilisearch'
 import { removeUndefinedFromObject } from './utils.js'
 import { createHighlighResult, createSnippetResult } from './format.js'
 
-export default function instantMeiliSearch(hostUrl, apiKey, options = {}) {
+export function instantMeiliSearch(hostUrl, apiKey, options = {}) {
   return {
     client: new MeiliSearch({ host: hostUrl, apiKey: apiKey }),
     attributesToHighlight: ['*'],

--- a/tests/base.test.js
+++ b/tests/base.test.js
@@ -1,4 +1,4 @@
-import instantMeiliSearch from '../src/index'
+import { instantMeiliSearch } from '../src/index'
 
 test('Should test if instantMeiliSearch Client is created correctly', () => {
   const client = instantMeiliSearch('http://localhost:7700', 'masterKey')

--- a/tests/env/esm/src/index.js
+++ b/tests/env/esm/src/index.js
@@ -1,4 +1,4 @@
-import instantMeiliSearch from '../../../../dist/instant-meilisearch.esm'
+import { instantMeiliSearch } from '../../../../dist/instant-meilisearch.esm'
 
 console.log(instantMeiliSearch)
 const client = instantMeiliSearch('http://localhost:7700', 'masterKey')

--- a/tests/env/node/index.js
+++ b/tests/env/node/index.js
@@ -1,5 +1,9 @@
-const UMDinstantMeiliSearch = require('../../../dist/instant-meilisearch.umd')
-const CJSinstantMeiliSearch = require('../../../dist/instant-meilisearch.cjs')
+const {
+  instantMeiliSearch: UMDinstantMeiliSearch,
+} = require('../../../dist/instant-meilisearch.umd')
+const {
+  instantMeiliSearch: CJSinstantMeiliSearch,
+} = require('../../../dist/instant-meilisearch.cjs')
 
 const UMDtest = UMDinstantMeiliSearch('http://localhost:7700', 'masterKey')
 const CJStest = CJSinstantMeiliSearch('http://localhost:7700', 'masterKey')


### PR DESCRIPTION
Following the decision taken in `meilisearch-js`: https://github.com/meilisearch/meilisearch-js/pull/756



# Named exports
MeiliSearch Js decided to go in the direction of new best practices in JS libraries by changing from default export to named export.

## New usage 

ES:
```javascript
import {instantMeiliSearch } from '@meilisearch/instant-meilisearch' // ES

const searchClient = instantMeiliSearch(...);
``` 

Node
```javascript
const { instantMeiliSearch } = require('@meilisearch/instant-meilisearch') // Node

const searchClient = instantMeiliSearch(...);
``` 

```javascript
instantMeiliSearch // browser
window.instantMeiliSearch // browser

const searchClient = instantMeiliSearch(...);
const searchClient2 = window.instantMeiliSearch(...);
``` 

