### PR TITLE
Make angular e2e tests more consistant

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,3 +51,12 @@ jobs:
         run: yarn install
       - name: Run Playgrounds Builds
         run: yarn test:playgrounds
+  e2e:
+    name: end-to-end tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install dependencies
+        run: yarn install
+      - name: Run end to end tests
+        run: yarn test:e2e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,12 +51,3 @@ jobs:
         run: yarn install
       - name: Run Playgrounds Builds
         run: yarn test:playgrounds
-  e2e:
-    name: end-to-end tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install dependencies
-        run: yarn install
-      - name: Run end to end tests
-        run: yarn test:e2e

--- a/playgrounds/angular/e2e/src/app.po.ts
+++ b/playgrounds/angular/e2e/src/app.po.ts
@@ -1,4 +1,6 @@
-import { browser, by, element } from 'protractor'
+import { browser, by, element, ExpectedConditions } from 'protractor'
+
+const timeOutError = 'Element taking too long to appear in the DOM'
 
 export class AppPage {
   async navigateTo(): Promise<unknown> {
@@ -6,14 +8,20 @@ export class AppPage {
   }
 
   async getFirstGame(): Promise<string> {
-    return await element(by.css('.ais-Hits-item > .hit-name')).getText()
+    const elem = element(by.css('.ais-Hits-item > .hit-name'))
+    await browser.wait(ExpectedConditions.presenceOf(elem), 5000, timeOutError)
+    return await elem.getText()
   }
 
   async getFirstFacetValueOfFirstFacet(): Promise<string> {
-    return await element(by.css('.ais-RefinementList-labelText')).getText()
+    const elem = element(by.css('.ais-RefinementList-labelText'))
+    await browser.wait(ExpectedConditions.presenceOf(elem), 5000, timeOutError)
+    return await elem.getText()
   }
 
   async getClearRefinementText(): Promise<string> {
-    return await element(by.css('.ais-ClearRefinements-button')).getText()
+    const elem = element(by.css('.ais-ClearRefinements-button'))
+    await browser.wait(ExpectedConditions.presenceOf(elem), 5000, timeOutError)
+    return await elem.getText()
   }
 }


### PR DESCRIPTION
Tests were failing when MeiliSearch instance did not respond fast enough. 
I added a wait for element to be sure we give meilisearch enough time. 