### PR TITLE
Fix processing time that was always 0 in Stats widget

### DIFF
--- a/playgrounds/react/src/App.js
+++ b/playgrounds/react/src/App.js
@@ -9,6 +9,7 @@ import {
   ClearRefinements,
   RefinementList,
   Configure,
+  Stats,
 } from 'react-instantsearch-dom'
 import './App.css'
 import { instantMeiliSearch } from '../../../src/index'
@@ -40,6 +41,7 @@ class App extends Component {
           indexName="steam-video-games"
           searchClient={searchClient}
         >
+          <Stats />
           <div className="left-panel">
             <ClearRefinements />
             <h2>Genres</h2>

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,7 +129,7 @@ export function instantMeiliSearch(
         ...(exhaustiveFacetsCount && { exhaustiveFacetsCount }),
         exhaustiveNbHits,
         nbHits,
-        processingTimeMs,
+        processingTimeMS: processingTimeMs,
         query,
         ...(pagination && pagination),
         hits: ISHits, // Apply pagination + highlight


### PR DESCRIPTION
Processing time provided to instantSearch was badly formatted, as instantSearch expects `processingTimeMS` and we provided `processingTimeMs` as per MeiliSearch naming in its response.