### PR TITLE
Fix infinite hits

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,4 +4,5 @@ build
 
 .cache
 
+# Avoid symbolic link linting
 tests/env/express/public/

--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,5 @@ dist
 build
 
 .cache
+
+tests/env/express/public/

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,5 @@ dist
 
 # parcel
 .parcel_cache/
+
+tests/env/express/public/

--- a/.gitignore
+++ b/.gitignore
@@ -108,5 +108,3 @@ dist
 
 # parcel
 .parcel_cache/
-
-tests/env/express/public/

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ const searchClient = instantMeiliSearch(
   "dc3fedaf922de8937fdea01f0a7d59557f1fd31832cb8440ce94231cfdde7f25",
   {
     paginationTotalHits: 30, // default: 200.
-    placeholderSearch: false // default: true.
+    placeholderSearch: false, // default: true.
     primaryKey: 'id' // default: undefined
   }
 );

--- a/playgrounds/react/src/App.js
+++ b/playgrounds/react/src/App.js
@@ -58,7 +58,7 @@ class App extends Component {
           <div className="right-panel">
             <SearchBox />
             <Hits hitComponent={Hit} />
-            <Pagination />
+            <Pagination showLast={true} />
           </div>
         </InstantSearch>
       </div>

--- a/playgrounds/react/src/App.js
+++ b/playgrounds/react/src/App.js
@@ -5,11 +5,11 @@ import {
   Hits,
   SearchBox,
   Pagination,
+  Stats,
   Highlight,
   ClearRefinements,
   RefinementList,
   Configure,
-  Stats,
 } from 'react-instantsearch-dom'
 import './App.css'
 import { instantMeiliSearch } from '../../../src/index'
@@ -58,7 +58,7 @@ class App extends Component {
           <div className="right-panel">
             <SearchBox />
             <Hits hitComponent={Hit} />
-            <Pagination showLast={true} />
+            <Pagination />
           </div>
         </InstantSearch>
       </div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,6 @@ export function instantMeiliSearch(
       },
       instantSearchParams
     ) {
-
       // Create response object compliant with InstantSearch
       const ISResponse = {
         index: indexUid,

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ export function instantMeiliSearch(
       const limit = this.paginationTotalHits
       const attributesToCrop = attributesToSnippet
 
-      // transform to meilisearch-js search param
+      // Creates search params object compliant with MeiliSearch
       return {
         q: query,
         ...(facets && { facetsDistribution: facets }),
@@ -67,7 +67,8 @@ export function instantMeiliSearch(
 
       return paginatedHits.map((hit: Record<string, any>) => {
         const { _formatted: formattedHit, ...restOfHit } = hit
-        // create Hit object that matches instantSearch requirements
+
+        // Creates Hit object compliant with InstantSearch
         return {
           ...restOfHit,
           _highlightResult: createHighlighResult({
@@ -96,7 +97,8 @@ export function instantMeiliSearch(
       },
       instantSearchParams
     ) {
-      // transform to InstantSearch search response requirements
+
+      // Create response object compliant with InstantSearch
       const ISResponse = {
         index: indexUid,
         hitsPerPage: this.hitsPerPage,
@@ -108,7 +110,7 @@ export function instantMeiliSearch(
         nbHits,
         processingTimeMS: processingTimeMs,
         query,
-        hits: this.transformToISHits(hits, instantSearchParams), // Apply pagination + highlight
+        hits: this.transformToISHits(hits, instantSearchParams),
       }
       return {
         results: [ISResponse],

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export function instantMeiliSearch(
     primaryKey: options.primaryKey || undefined,
     placeholderSearch: options.placeholderSearch !== false, // true by default
     hitsPerPage: 20,
+    page: 0,
     /*
       REQUEST CONSTRUCTION
     */
@@ -56,12 +57,12 @@ export function instantMeiliSearch(
       RESPONSE CONSTRUCTION
     */
 
-    createISPaginationParams: function (hitsLength, { page }) {
+    createISPaginationParams: function (hitsLength) {
       const adjust = hitsLength % this.hitsPerPage! === 0 ? 0 : 1
       const nbPages = Math.floor(hitsLength / this.hitsPerPage!) + adjust
       return {
         nbPages, // total number of pages
-        page: page || 0, // the current page, information sent by InstantSearch
+        page: this.page, // the current page, information sent by InstantSearch
       }
     },
 
@@ -112,21 +113,18 @@ export function instantMeiliSearch(
       },
       instantSearchParams
     ) {
-      const pagination = this.createISPaginationParams(
-        hits.length,
-        instantSearchParams
-      )
+      const pagination = this.createISPaginationParams(hits.length)
       const ISHits = this.transformToISHits(hits, instantSearchParams)
       const ISResponse = {
         index: indexUid,
         hitsPerPage: this.hitsPerPage,
         ...(facets && { facets }),
         ...(exhaustiveFacetsCount && { exhaustiveFacetsCount }),
+        ...pagination,
         exhaustiveNbHits,
         nbHits,
         processingTimeMS: processingTimeMs,
         query,
-        ...(pagination && pagination),
         hits: ISHits, // Apply pagination + highlight
       }
       return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,13 +27,12 @@ export function instantMeiliSearch(
       query,
       facets,
       facetFilters,
-      attributesToSnippet,
+      attributesToSnippet: attributesToCrop,
       attributesToRetrieve,
       attributesToHighlight,
       filters,
     }) {
       const limit = this.paginationTotalHits
-      const attributesToCrop = attributesToSnippet
 
       // Creates search params object compliant with MeiliSearch
       return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,6 @@ export function instantMeiliSearch(
 ): InstantMeiliSearchInstance {
   return {
     client: new MeiliSearch({ host: hostUrl, apiKey: apiKey }),
-    attributesToHighlight: ['*'],
     paginationTotalHits: options.paginationTotalHits || 200,
     primaryKey: options.primaryKey || undefined,
     placeholderSearch: options.placeholderSearch !== false, // true by default
@@ -31,25 +30,18 @@ export function instantMeiliSearch(
       filters,
     }) {
       const limit = this.paginationTotalHits
+      const attributesToCrop = attributesToSnippet
 
+      // transform to meilisearch-js search params
       return {
         q: query,
-        facets: facets || { facetsDistribution: [] },
-        ...(facets?.length && { facetsDistribution: facets }),
+        attributesToHighlight: ['*'],
+        ...(facets && { facetsDistribution: facets }),
         ...(facetFilters && { facetFilters }),
-        ...(this.attributesToHighlight && {
-          attributesToHighlight: this.attributesToHighlight,
-        }),
-        ...(attributesToSnippet && {
-          attributesToCrop: attributesToSnippet,
-        }),
+        ...(attributesToCrop && { attributesToCrop }),
         ...(attributesToRetrieve && { attributesToRetrieve }),
         ...(filters && { filters }),
-        limit:
-          (this.placeholderSearch === false && query === '') ||
-          limit === undefined
-            ? 0
-            : limit,
+        limit: (!this.placeholderSearch && query === '') || !limit ? 0 : limit,
       }
     },
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,8 +54,7 @@ export function instantMeiliSearch(
 
     getNumberPages: function (hitsLength) {
       const adjust = hitsLength % this.hitsPerPage! === 0 ? 0 : 1
-      const page = Math.floor(hitsLength / this.hitsPerPage!) + adjust
-      return page // total number of pages
+      return Math.floor(hitsLength / this.hitsPerPage!) + adjust // total number of pages
     },
 
     paginateHits: function (hits) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,13 +160,11 @@ export function instantMeiliSearch(
           .search(msSearchParams.q, msSearchParams)
 
         // Parses the MeiliSearch response and returns it for InstantSearch
-        const res = this.transformToISResponse(
+        return this.transformToISResponse(
           indexUid,
           searchResponse,
           instantSearchParams
         )
-        console.log(res)
-        return res
       } catch (e) {
         console.error(e)
         throw new Error(e)

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,8 +56,7 @@ export type InstantMeiliSearchInstance = {
     instantSearchParams: ISSearchParams
   ) => ISHits[]
   createISPaginationParams: (
-    hitsLength: number,
-    instantSearchParams: ISSearchParams
+    hitsLength: number
   ) => { nbPages: number; page: number | undefined } | undefined
   paginateISHits: (
     { page }: ISSearchParams,

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,7 @@ export type SearchResponse = IStypes.SearchResponse & IMResponse
 export type instantSearchUtils = {}
 
 export type InstantMeiliSearchInstance = {
-  pagination?: boolean
+  page?: number
   paginationTotalHits: number
   hitsPerPage: number
   primaryKey: string | undefined

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,12 +33,11 @@ export type SearchResponse = IStypes.SearchResponse & IMResponse
 export type instantSearchUtils = {}
 
 export type InstantMeiliSearchInstance = {
-  page?: number
+  page: number
   paginationTotalHits: number
   hitsPerPage: number
   primaryKey: string | undefined
   client: MStypes.MeiliSearch
-  attributesToHighlight: string[]
   placeholderSearch: boolean
 
   transformToISResponse: (
@@ -55,11 +54,8 @@ export type InstantMeiliSearchInstance = {
     meiliSearchHits: Array<Record<string, any>>,
     instantSearchParams: ISSearchParams
   ) => ISHits[]
-  createISPaginationParams: (
-    hitsLength: number
-  ) => { nbPages: number; page: number | undefined } | undefined
-  paginateISHits: (
-    { page }: ISSearchParams,
+  getNumberPages: (hitsLength: number) => number
+  paginateHits: (
     meiliSearchHits: Array<Record<string, any>>
   ) => Array<Record<string, any>>
   search: (

--- a/tests/base.test.ts
+++ b/tests/base.test.ts
@@ -3,6 +3,5 @@ import { instantMeiliSearch } from '../src/index'
 test('Should test if instantMeiliSearch Client is created correctly', () => {
   const client = instantMeiliSearch('http://localhost:7700', 'masterKey')
   expect(client.paginationTotalHits).toBe(200)
-  expect(client.attributesToHighlight[0]).toBe('*')
   expect(client.placeholderSearch).toBe(true)
 })

--- a/tests/env/express/tests/client.test.js
+++ b/tests/env/express/tests/client.test.js
@@ -5,7 +5,7 @@ describe('Instant MeiliSearch Browser test', () => {
 
   it('Should have generated a instant-meilisearch client and displayed', async () => {
     await expect(page.content()).resolves.toMatch(
-      '{"client":{"config":{"host":"http://localhost:7700/","apiKey":"masterKey"},"httpRequest":{"headers":{"Content-Type":"application/json","X-Meili-API-Key":"masterKey"},"url":"http://localhost:7700/"}},"attributesToHighlight":["*"],"paginationTotalHits":200,"placeholderSearch":true,"hitsPerPage":20}'
+      '{"client":{"config":{"host":"http://localhost:7700/","apiKey":"masterKey"},"httpRequest":{"headers":{"Content-Type":"application/json","X-Meili-API-Key":"masterKey"},"url":"http://localhost:7700/"}},"attributesToHighlight":["*"],"paginationTotalHits":200,"placeholderSearch":true,"hitsPerPage":20,"page":0}'
     )
   })
 })

--- a/tests/env/express/tests/client.test.js
+++ b/tests/env/express/tests/client.test.js
@@ -5,7 +5,7 @@ describe('Instant MeiliSearch Browser test', () => {
 
   it('Should have generated a instant-meilisearch client and displayed', async () => {
     await expect(page.content()).resolves.toMatch(
-      '{"client":{"config":{"host":"http://localhost:7700/","apiKey":"masterKey"},"httpRequest":{"headers":{"Content-Type":"application/json","X-Meili-API-Key":"masterKey"},"url":"http://localhost:7700/"}},"attributesToHighlight":["*"],"paginationTotalHits":200,"placeholderSearch":true,"hitsPerPage":20,"page":0}'
+      '{"client":{"config":{"host":"http://localhost:7700/","apiKey":"masterKey"},"httpRequest":{"headers":{"Content-Type":"application/json","X-Meili-API-Key":"masterKey"},"url":"http://localhost:7700/"}},"paginationTotalHits":200,"placeholderSearch":true,"hitsPerPage":20,"page":0}'
     )
   })
 })

--- a/tests/env/node/node.test.js
+++ b/tests/env/node/node.test.js
@@ -2,14 +2,12 @@ const { UMDclient, CJSclient } = require('./index')
 const instantsearch = require('instantsearch.js')
 
 test('UMD client should correctly created', () => {
-  expect(UMDclient.attributesToHighlight).toStrictEqual(['*'])
   expect(UMDclient.placeholderSearch).toBe(true)
   expect(UMDclient.hitsPerPage).toBe(20)
   expect(UMDclient.client.config.apiKey).toBe('masterKey')
 })
 
 test('CJS client should correctly created', () => {
-  expect(CJSclient.attributesToHighlight).toStrictEqual(['*'])
   expect(CJSclient.placeholderSearch).toBe(true)
   expect(CJSclient.hitsPerPage).toBe(20)
   expect(CJSclient.client.config.apiKey).toBe('masterKey')
@@ -23,7 +21,6 @@ test('CJS instantsearch client should correctly created', () => {
   // console.log(CJSInstantSearch.client.search())
   expect(CJSInstantSearch.indexName).toBe('cjs_index')
   expect(CJSInstantSearch.client.client.config.apiKey).toBe('masterKey')
-  expect(CJSInstantSearch.client.attributesToHighlight).toStrictEqual(['*'])
   expect(CJSInstantSearch.client.placeholderSearch).toBe(true)
   expect(CJSInstantSearch.client.hitsPerPage).toBe(20)
 })
@@ -36,7 +33,6 @@ test('UMD instantsearch client should correctly created', () => {
   // console.log(UMDInstantSearch.client.search())
   expect(UMDInstantSearch.indexName).toBe('umd_index')
   expect(UMDInstantSearch.client.client.config.apiKey).toBe('masterKey')
-  expect(UMDInstantSearch.client.attributesToHighlight).toStrictEqual(['*'])
   expect(UMDInstantSearch.client.placeholderSearch).toBe(true)
   expect(UMDInstantSearch.client.hitsPerPage).toBe(20)
 })


### PR DESCRIPTION
Fix `<InfiniteHits />` that did not work without `<Pagination />`

Refactor code a bit to make it more readable. 
Removed `attributesToHighlight` from client params as they were always equal to `['*']`. 

Also updated `transformToMeiliSearchParams` to fetch `attributesToHighlight` from `instantsearch.js`  to compare it with ours.

It is also never going to be used by `instantSearch` as it is not a requested option in a `SearchClient` (see below)

```javascript
export declare type SearchClient = {
    addAlgoliaAgent?: (agent: string) => void;
    search: (requests: SearchRequest[]) => Promise<{
        results: SearchResponse[];
    }>;
    searchForFacetValues?: (requests: SearchForFacetValuesRequest[]) => Promise<{
        facetHits: SearchForFacetValuesResponse[];
    }[]>;
};
```