### PR TITLE
Fix nested object being transfom into [object, object] in highlight

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -6,14 +6,18 @@ function replaceHighlightTags(
   highlightPreTag?: string,
   highlightPostTag?: string
 ): string {
-  // Value has to be a string.
-  // Some field may have highlight applied by MeiliSearch (<em> tags)
+  // Value has to be a string to have highlight.
+  // Highlight is applied by MeiliSearch (<em> tags)
   // We replace the <em> by the expected tag for InstantSearch
   highlightPreTag = highlightPreTag || '__ais-highlight__'
   highlightPostTag = highlightPostTag || '__/ais-highlight__'
+  if (isString(value)) {
+    return value
+      .replace(/<em>/g, highlightPreTag)
+      .replace(/<\/em>/g, highlightPostTag)
+  }
+  // We JSON stringify to avoid loss of nested information
   return JSON.stringify(value)
-    .replace(/<em>/g, highlightPreTag)
-    .replace(/<\/em>/g, highlightPostTag)
 }
 
 function createHighlighResult<T extends Record<string, any>>({

--- a/src/format.ts
+++ b/src/format.ts
@@ -6,17 +6,14 @@ function replaceHighlightTags(
   highlightPreTag?: string,
   highlightPostTag?: string
 ): string {
-  // If the value of the attribute is a string,
-  // the highlight is applied by MeiliSearch (<em> tags)
-  // and we replace the <em> by the expected tag for InstantSearch
-  if (isString(value)) {
-    highlightPreTag = highlightPreTag || '__ais-highlight__'
-    highlightPostTag = highlightPostTag || '__/ais-highlight__'
-    return value
-      .replace(/<em>/g, highlightPreTag)
-      .replace(/<\/em>/g, highlightPostTag)
-  }
-  return value
+  // Value has to be a string.
+  // Some field may have highlight applied by MeiliSearch (<em> tags)
+  // We replace the <em> by the expected tag for InstantSearch
+  highlightPreTag = highlightPreTag || '__ais-highlight__'
+  highlightPostTag = highlightPostTag || '__/ais-highlight__'
+  return JSON.stringify(value)
+    .replace(/<em>/g, highlightPreTag)
+    .replace(/<\/em>/g, highlightPostTag)
 }
 
 function createHighlighResult<T extends Record<string, any>>({

--- a/src/format.ts
+++ b/src/format.ts
@@ -6,7 +6,7 @@ function replaceHighlightTags(
   highlightPreTag?: string,
   highlightPostTag?: string
 ): string {
-  let newHighlightValue = value || ''
+  let newHighlightValue = JSON.stringify(value) || ''
   // If the value of the attribute is a string,
   // the highlight is applied by MeiliSearch (<em> tags)
   // and we replace the <em> by the expected tag for InstantSearch

--- a/src/format.ts
+++ b/src/format.ts
@@ -6,18 +6,17 @@ function replaceHighlightTags(
   highlightPreTag?: string,
   highlightPostTag?: string
 ): string {
-  let newHighlightValue = JSON.stringify(value) || ''
   // If the value of the attribute is a string,
   // the highlight is applied by MeiliSearch (<em> tags)
   // and we replace the <em> by the expected tag for InstantSearch
-  highlightPreTag = highlightPreTag || '__ais-highlight__'
-  highlightPostTag = highlightPostTag || '__/ais-highlight__'
   if (isString(value)) {
-    newHighlightValue = value
+    highlightPreTag = highlightPreTag || '__ais-highlight__'
+    highlightPostTag = highlightPostTag || '__/ais-highlight__'
+    return value
       .replace(/<em>/g, highlightPreTag)
       .replace(/<\/em>/g, highlightPostTag)
   }
-  return newHighlightValue.toString()
+  return value
 }
 
 function createHighlighResult<T extends Record<string, any>>({


### PR DESCRIPTION
The body of _highlightedResult used to look like this:

![Capture d’écran 2021-03-25 à 14 42 51](https://user-images.githubusercontent.com/33010418/112482638-90364600-8d78-11eb-93f3-bdfff1f4563a.png)

The field should be transformed to String using `JSON.stringify` to keep all information. 

<img width="923" alt="Screenshot 2021-03-25 at 15 20 33" src="https://user-images.githubusercontent.com/33010418/112488467-d93cc900-8d7d-11eb-9bc2-b1d4e26299a8.png">
It looks like this with this fix. 

