### PR TITLE
Fix failing search on missing facets

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ export function instantMeiliSearch(
       // Creates search params object compliant with MeiliSearch
       return {
         q: query,
-        ...(facets && { facetsDistribution: facets }),
+        ...(facets?.length && { facetsDistribution: facets }),
         ...(facetFilters && { facetFilters }),
         ...(attributesToCrop && { attributesToCrop }),
         ...(attributesToRetrieve && { attributesToRetrieve }),


### PR DESCRIPTION
Avoid this error on search 
```bash
MeiliSearchApiError: Can't perform facet count, as no facet is set
```

Fixes also hitsPerPage being ignored.