### PR TITLE
Communicate filters and numeric filters properly to instantsearch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,9 +30,15 @@ export function instantMeiliSearch(
       attributesToSnippet: attributesToCrop,
       attributesToRetrieve,
       attributesToHighlight,
-      filters,
+      filters = '',
+      numericFilters = [],
     }) {
       const limit = this.paginationTotalHits
+
+      const filter = [numericFilters.join(' AND '), filters.trim()]
+        .filter((x) => x)
+        .join(' AND ')
+        .trim()
 
       // Creates search params object compliant with MeiliSearch
       return {
@@ -41,7 +47,7 @@ export function instantMeiliSearch(
         ...(facetFilters && { facetFilters }),
         ...(attributesToCrop && { attributesToCrop }),
         ...(attributesToRetrieve && { attributesToRetrieve }),
-        ...(filters && { filters }),
+        ...(filter && { filters: filter }),
         attributesToHighlight: attributesToHighlight || ['*'],
         limit: (!this.placeholderSearch && query === '') || !limit ? 0 : limit,
       }


### PR DESCRIPTION
See: https://github.com/meilisearch/meilisearch-vue/issues/21

Numeric filters were not added to instantsearch's filters field. 

Demo: https://codesandbox.io/s/meilisearch-boardgames-uj2tr?file=/src/App.vue