### PR TITLE
Add sort by widget compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -801,7 +801,7 @@ The items list is composed of objects containing every sort possibilities you wa
 
 #### Sort formula
 
-The sort formula is synthaxed like this: `index:attribute:order`.
+A sort formula is expressed like this: `index:attribute:order`.
 
 `index` is mandatory, and when adding `attribute:order`, they must always be added together.
 

--- a/README.md
+++ b/README.md
@@ -795,9 +795,7 @@ The usage of the `SortBy` widget differs from the one found in Algolia's documen
 - Sort using different indexes.
 - Different `sort` rules on the same index.
 
-The items list is composed of objects containing every sort possibilities you want to provide to your used.
-
-The items attribute is an array of objects containing two attributes:
+The items list is composed of objects containing every sort possibilities you want to provide to your user. Each objects must contain two fields:
   - `label`: What is showcased on the user interface ex: `Sort by Ascending Price`
   - `value`: The sort formula.
 

--- a/README.md
+++ b/README.md
@@ -818,7 +818,9 @@ In this scenario, in the `clothes` index, we want the price to be sorted in an a
 
 #### Relevancy
 
-The importance of the sort value is determined by the [`ranking-rules`](https://docs.meilisearch.com/learn/core_concepts/relevancy.html#ranking-rules) of each index. It is possible to change the ranking-rules in the index settings. Or make multiple indexes with different ranking-rules order. See [relevancy guide](https://docs.meilisearch.com/learn/core_concepts/relevancy.html#relevancy).
+The impact sorting has on the returned hits is determined by the [`ranking-rules`](https://docs.meilisearch.com/learn/core_concepts/relevancy.html#ranking-rules) ordered list of each index. The `sort` ranking-rule position in the list makes sorting documents more or less important than other rules. If you want to change the sort impact on the relevancy, it is possible to change it in the [ranking-rule setting](https://docs.meilisearch.com/reference/api/ranking_rules.html#update-ranking-rules). For example, to favor exhaustivity over relevancy.
+
+See [relevancy guide](https://docs.meilisearch.com/learn/core_concepts/relevancy.html#relevancy).
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -805,7 +805,7 @@ A sort formula is expressed like this: `index:attribute:order`.
 
 `index` is mandatory, and when adding `attribute:order`, they must always be added together.
 
-When sorting on an attribute, the attribute has to be added in the [`SortableAttribute`](#link-to-doc) setting on your index.
+When sorting on an attribute, the attribute has to be added in the [`SortableAttributes`](#link-to-doc) setting on your index.
 
 Example:
 ```js

--- a/README.md
+++ b/README.md
@@ -189,6 +189,47 @@ This package only guarantees the compatibility with the [version v0.22.0 of Meil
 
 List of all the components that are available in [instantSearch](https://github.com/algolia/instantsearch.js) and their compatibilty with [MeiliSearch](https://github.com/meilisearch/meilisearch/).
 
+### Table Of Widgets
+
+- ✅ [InstantSearch](#-instantsearch)
+- ❌[index](#-index)
+- ✅ [SearchBox](#-searchbox)
+- ✅ [Configure](#-configure)
+- ❌[ConfigureRelatedItems](#-configure-related-items)
+- ❌[Autocomplete](#-autocomplete)
+- ✅ [Voice Search](#-voice-search)
+- ✅ [Insight](#-insight)
+- ✅ [Middleware](#-middleware)
+- ✅ [RenderState](#-renderstate)
+- ✅ [Hits](#-hits)
+- ✅ [InfiniteHits](#-infinitehits)
+- ✅ [Highlight](#-highlight)
+- ✅ [Snippet](#-snippet)
+- ❌[Geo Search](#-geo-search)
+- ❌[Answers](#-answers)
+- ✅ [RefinementList](#-refinementlist)
+- ❌[HierarchicalMenu](#-hierarchicalmenu)
+- ✅ [RangeSlider](#-rangeslider)
+- ✅ [Menu](#-menu)
+- ✅ [currentRefinements](#-currentrefinements)
+- ✅ [RangeInput](#-rangeinput)
+- ✅ [MenuSelect](#-menuselect)
+- ✅ [ToggleRefinement](#-togglerefinement)
+- ✅ [NumericMenu](#-numericmenu)
+- ❌[RatingMenu](#-ratingmenu)
+- ✅ [ClearRefinements](#-clearrefinements)
+- ✅ [Pagination](#-pagination)
+- ✅ [HitsPerPage](#-hitsperpage)
+- ❌[Breadcrumb](#-breadcrumb)
+- ✅ [Stats](#-stats)
+- ❌[Analytics](#-analytics)
+- ❌[QueryRuleCustomData](#-queryrulecustomdata)
+- ❌[QueryRuleContext](#-queryrulecontext)
+- ✅ [SortBy](#-sortby)
+- ❌[RelevantSort](#-relevantsort)
+- ✅ [Routing](#-routing)
+
+
 ### ✅ InstantSearch
 
 [instantSearch references](https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/)
@@ -521,7 +562,7 @@ Min and max of attributes are not returned from MeiliSearch and thus **must be s
 
 If the attribute is not in the [`filterableAttributes`](https://docs.meilisearch.com/reference/features/filtering_and_faceted_search.html#configuring-filters) setting list, filtering on this attribute is not possible.
 
-Example: 
+Example:
 Given the attribute `id` that has not been added in `filterableAttributes`:
 
 ```js
@@ -738,15 +779,71 @@ The queryRuleContext widget lets you apply ruleContexts based on filters to trig
 
 No compatibility because MeiliSearch does not support Rules.
 
-### ❌ SortBy
+### ✅ SortBy
 
 [Sort by references](https://www.algolia.com/doc/api-reference/widgets/sort-by/js/)
 
-The sortBy widget displays a list of indices, allowing a user to change the way hits are sorted (with replica indices). Another common use case is to let the user switch between different indices.
+The `sortBy` widget is used to create multiple sort formulas. Allowing a user to change the way hits are sorted.
 
-No compatibility because MeiliSearch does not support hierarchical facets.
+- ✅ container: The CSS Selector or HTMLElement to insert the widget into. _required_
+- ✅ items: The list of different sorting possibilities. _required_
+- ✅ cssClasses: The CSS classes to override.
+- ✅ transformItems: function receiving the items, called before displaying them.
 
-If you'd like to get the "SortBy" feature, please vote for it in the [roadmap]https://roadmap.meilisearch.com/c/32-sort-by?utm_medium=social&utm_source=portal_share).
+The usage of the `SortBy` widget differs from the one found in Algolia's documentation. In instant-meilisearch the following is possible:
+
+- Sort using different indexes.
+- Different `sort` rules on the same index.
+
+The items list is composed of objects containing every sort possibilities you want to provide to your used.
+
+The items attribute is an array of objects containing two attributes:
+  - `label`: What is showcased on the user interface ex: `Sort by Ascending Price`
+  - `value`: The sort formula.
+
+#### Sort formula
+
+The sort formula is synthaxed like this: `index:attribute:order`.
+
+`index` is mandatory, and when adding `attribute:order`, they must always be added together.
+
+When sorting on an attribute, the attribute has to be added in the [`SortableAttribute`](#link-to-doc) setting on your index.
+
+Example:
+```js
+[
+  { label: 'Sort By Price', value: 'clothes:price:asc' }
+]
+```
+
+In this scenario, in the `clothes` index, we want the price to be sorted in an ascending way. For this formula to be valid, `price` must be added in the `sortableAttributes` settings of the `clothes` index.
+
+#### Relevancy
+
+The importance of the sort value is determined by the [`ranking-rules`](https://docs.meilisearch.com/learn/core_concepts/relevancy.html#ranking-rules) of each index. It is possible to change the ranking-rules in the index settings. Or make multiple indexes with different ranking-rules order. See [relevancy guide](https://docs.meilisearch.com/learn/core_concepts/relevancy.html#relevancy).
+
+#### Example
+
+```js
+  instantsearch.widgets.sortBy({
+    container: '#sort-by',
+    items: [
+      { value: 'clothes', label: 'Relevant' }, // default index
+      {
+        value: 'clothes:price:asc', // Sort on descending price
+        label: 'Ascending price using query time sort',
+      },
+      {
+        value: 'clothes:price:asc', // Sort on ascending price
+        label: 'Descending price using query time sort',
+      },
+      {
+        value: 'clothes-sorted', // different index with different ranking rules.
+        label: 'Custom sort using a different index',
+      },
+    ],
+  }),
+```
 
 ### ❌ RelevantSort
 

--- a/cypress/integration/search-ui.spec.js
+++ b/cypress/integration/search-ui.spec.js
@@ -42,6 +42,20 @@ describe(`${playground} playground test`, () => {
     cy.get(HIT_ITEM_CLASS).eq(0).contains('9.99 $')
   })
 
+  it('Sort by recommendationCound ascending', () => {
+    const select = `.ais-SortBy-select`
+    cy.get(select).select('steam-video-games:recommendationCount:asc')
+    cy.wait(1000)
+    cy.get(HIT_ITEM_CLASS).eq(0).contains('Rag Doll Kung Fu')
+  })
+
+  it('Sort by default relevancy', () => {
+    const select = `.ais-SortBy-select`
+    cy.get(select).select('steam-video-games')
+    cy.wait(1000)
+    cy.get(HIT_ITEM_CLASS).eq(0).contains('Counter-Strike')
+  })
+
   it('click on facets', () => {
     const checkbox = `.ais-RefinementList-list .ais-RefinementList-checkbox`
     cy.get(checkbox).eq(1).click()

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:e2e:all": "sh scripts/e2e.sh",
     "test:e2e:watch": "concurrently --kill-others -s first \"NODE_ENV=test yarn playground:javascript\" \"cypress open --env playground=javascript\"",
     "test:all": "yarn test:e2e:all && yarn test && test:build",
+    "cy:open": "cypress open",
     "playground:vue": "yarn --cwd ./playgrounds/vue && yarn --cwd ./playgrounds/vue serve",
     "playground:react": "yarn --cwd ./playgrounds/react && yarn --cwd ./playgrounds/react start",
     "playground:javascript": "yarn --cwd ./playgrounds/javascript && yarn --cwd ./playgrounds/javascript start",

--- a/playgrounds/angular/src/app/app.component.html
+++ b/playgrounds/angular/src/app/app.component.html
@@ -10,6 +10,19 @@
     <div class="search-panel">
       <div class="search-panel__filters">
         <ais-clear-refinements></ais-clear-refinements>
+        <ais-sort-by
+          [items]="[
+          { value: 'steam-video-games', label: 'Relevant' },
+          {
+            value: 'steam-video-games:recommendationCount:desc',
+            label: 'Most Recommended'
+          },
+          {
+            value: 'steam-video-games:recommendationCount:asc',
+            label: 'Least Recommended'
+          }
+          ]"
+        ></ais-sort-by>
         <ais-configure [searchParameters]="{ hitsPerPage: 6 }"></ais-configure>
         <h2>Genres</h2>
         <ais-refinement-list attribute="genres" ></ais-refinement-list>
@@ -40,8 +53,9 @@
                 <div class="hit-description">
                   <ais-highlight attribute="description" [hit]="hit"></ais-highlight>
                 </div>
-                <div class="hit-info">${{hit.price}}</div>
-                <div class="hit-info">{{hit.releaseDate}}</div>
+                <div class="hit-info">price: ${{hit.price}}</div>
+                <div class="hit-info">Release date: {{hit.releaseDate}}</div>
+                <div class="hit-info">Recommendation: {{hit.recommendationCount}}</div>
               </li>
             </ol>
           </ng-template>

--- a/playgrounds/angular/src/app/app.component.ts
+++ b/playgrounds/angular/src/app/app.component.ts
@@ -2,8 +2,8 @@ import { Component } from '@angular/core'
 import { instantMeiliSearch } from '../../../../src'
 
 const searchClient = instantMeiliSearch(
-  'https://ms-9060336c1f95-106.saas.meili.dev',
-  '5d7e1929728417466fd5a82da5a28beb540d3e5bbaf4e01f742e1fb5fd72bb66'
+  'https://demo-steam.meilisearch.com/',
+  '90b03f9c47d0f321afae5ae4c4e4f184f53372a2953ab77bca679ff447ecc15c'
 )
 
 @Component({

--- a/playgrounds/html/public/index.html
+++ b/playgrounds/html/public/index.html
@@ -25,10 +25,10 @@
       const search = instantsearch({
           indexName: "steam-video-games",
           searchClient: instantMeiliSearch(
-            'https://ms-9060336c1f95-106.saas.meili.dev',
-            '5d7e1929728417466fd5a82da5a28beb540d3e5bbaf4e01f742e1fb5fd72bb66',
+            'https://demo-steam.meilisearch.com',
+            '90b03f9c47d0f321afae5ae4c4e4f184f53372a2953ab77bca679ff447ecc15c',
           )
-          });
+      });
       search.addWidgets([
         instantsearch.widgets.searchBox({
             container: "#searchbox",

--- a/playgrounds/javascript/index.html
+++ b/playgrounds/javascript/index.html
@@ -29,7 +29,7 @@
 
       <div class="left-panel">
         <div id="clear-refinements"></div>
-
+        <div id="sort-by"></div>
         <h2>Genres</h2>
         <div id="genres-list"></div>
         <h2>Players</h2>

--- a/playgrounds/javascript/src/app.js
+++ b/playgrounds/javascript/src/app.js
@@ -3,8 +3,8 @@ import { instantMeiliSearch } from '../../../src/index'
 const search = instantsearch({
   indexName: 'steam-video-games',
   searchClient: instantMeiliSearch(
-    'https://ms-9060336c1f95-106.saas.meili.dev',
-    '5d7e1929728417466fd5a82da5a28beb540d3e5bbaf4e01f742e1fb5fd72bb66',
+    'https://demo-steam.meilisearch.com',
+    '90b03f9c47d0f321afae5ae4c4e4f184f53372a2953ab77bca679ff447ecc15c',
     {
       limitPerRequest: 30,
     }
@@ -12,6 +12,20 @@ const search = instantsearch({
 })
 
 search.addWidgets([
+  instantsearch.widgets.sortBy({
+    container: '#sort-by',
+    items: [
+      { value: 'steam-video-games', label: 'Relevant' },
+      {
+        value: 'steam-video-games:recommendationCount:desc',
+        label: 'Most Recommended',
+      },
+      {
+        value: 'steam-video-games:recommendationCount:asc',
+        label: 'Least Recommended',
+      },
+    ],
+  }),
   instantsearch.widgets.searchBox({
     container: '#searchbox',
   }),
@@ -32,6 +46,7 @@ search.addWidgets([
   }),
   instantsearch.widgets.configure({
     hitsPerPage: 6,
+    attributesToSnippet: ['description:150'],
   }),
   instantsearch.widgets.refinementList({
     container: '#misc-list',
@@ -51,6 +66,7 @@ search.addWidgets([
           </div>
           <div class="hit-info">price: {{price}}</div>
           <div class="hit-info">release date: {{releaseDate}}</div>
+          <div class="hit-info">Recommendation: {{recommendationCount}}</div>
         </div>
       `,
     },

--- a/playgrounds/react/src/App.js
+++ b/playgrounds/react/src/App.js
@@ -9,13 +9,16 @@ import {
   ClearRefinements,
   RefinementList,
   Configure,
+  SortBy,
+  Snippet,
 } from 'react-instantsearch-dom'
+
 import './App.css'
 import { instantMeiliSearch } from '../../../src/index'
 
 const searchClient = instantMeiliSearch(
-  'https://ms-9060336c1f95-106.saas.meili.dev',
-  '5d7e1929728417466fd5a82da5a28beb540d3e5bbaf4e01f742e1fb5fd72bb66',
+  'https://demo-steam.meilisearch.com/',
+  '90b03f9c47d0f321afae5ae4c4e4f184f53372a2953ab77bca679ff447ecc15c',
   {
     paginationTotalHits: 60,
     primaryKey: 'id',
@@ -39,6 +42,20 @@ const App = () => (
       <Stats />
       <div className="left-panel">
         <ClearRefinements />
+        <SortBy
+          defaultRefinement="steam-video-games"
+          items={[
+            { value: 'steam-video-games', label: 'Relevant' },
+            {
+              value: 'steam-video-games:recommendationCount:desc',
+              label: 'Most Recommended',
+            },
+            {
+              value: 'steam-video-games:recommendationCount:asc',
+              label: 'Least Recommended',
+            },
+          ]}
+        />
         <h2>Genres</h2>
         <RefinementList attribute="genres" />
         <h2>Players</h2>
@@ -47,7 +64,11 @@ const App = () => (
         <RefinementList attribute="platforms" />
         <h2>Misc</h2>
         <RefinementList attribute="misc" />
-        <Configure hitsPerPage={6} />
+        <Configure
+          hitsPerPage={6}
+          attributesToSnippet={['description:50']}
+          snippetEllipsisText={'...'}
+        />
       </div>
       <div className="right-panel">
         <SearchBox />
@@ -57,18 +78,27 @@ const App = () => (
   </div>
 )
 
-const Hit = ({ hit }) => (
-  <div key={hit.id}>
-    <div className="hit-name">
-      <Highlight attribute="name" hit={hit} />
+const Hit = ({ hit }) => {
+  return (
+    <div key={hit.id}>
+      <div className="hit-name">
+        <Highlight attribute="name" hit={hit} />
+      </div>
+      <img src={hit.image} align="left" alt={hit.name} />
+      <div className="hit-name">
+        <Snippet attribute="description" hit={hit} />
+      </div>
+      <div className="hit-info">
+        <b>price:</b> {hit.price}
+      </div>
+      <div className="hit-info">
+        <b>release date:</b> {hit.releaseDate}
+      </div>
+      <div className="hit-info">
+        <b>Recommended:</b> {hit.recommendationCount}
+      </div>
     </div>
-    <img src={hit.image} align="left" alt={hit.name} />
-    <div className="hit-name">
-      <Highlight attribute="description" hit={hit} />
-    </div>
-    <div className="hit-info">price: {hit.price}</div>
-    <div className="hit-info">release date: {hit.releaseDate}</div>
-  </div>
-)
+  )
+}
 
 export default App

--- a/playgrounds/vue/src/App.vue
+++ b/playgrounds/vue/src/App.vue
@@ -17,6 +17,19 @@
           <ais-clear-refinements>
             <span slot="resetLabel">Clear all filters</span>
           </ais-clear-refinements>
+          <ais-sort-by
+            :items="[
+              { value: 'steam-video-games', label: 'Relevant' },
+              {
+                value: 'steam-video-games:recommendationCount:desc',
+                label: 'Most Recommended',
+              },
+              {
+                value: 'steam-video-games:recommendationCount:asc',
+                label: 'Least Recommended',
+              },
+            ]"
+          />
           <h2>Genres</h2>
           <ais-refinement-list attribute="genres" />
           <h2>Players</h2>
@@ -40,8 +53,11 @@
                 <div class="hit-description">
                   <ais-snippet :hit="item" attribute="description" />
                 </div>
-                <div class="hit-info">price: {{ item.price }}</div>
-                <div class="hit-info">release date: {{ item.releaseDate }}</div>
+                <div class="hit-info">Price: {{ item.price }}</div>
+                <div class="hit-info">Release date: {{ item.releaseDate }}</div>
+                <div class="hit-info">
+                  Recommended: {{ item.recommendationCount }}
+                </div>
               </div>
             </template>
           </ais-hits>
@@ -66,11 +82,20 @@ import { instantMeiliSearch } from '../../../src/index'
 export default {
   data() {
     return {
+      recommendation: '',
       searchClient: instantMeiliSearch(
-        'https://ms-9060336c1f95-106.saas.meili.dev',
-        '5d7e1929728417466fd5a82da5a28beb540d3e5bbaf4e01f742e1fb5fd72bb66'
+        'https://demo-steam.meilisearch.com',
+        '90b03f9c47d0f321afae5ae4c4e4f184f53372a2953ab77bca679ff447ecc15c'
       ),
     }
+  },
+  methods: {
+    order: function (event, searchParameters, refine) {
+      refine({
+        ...searchParameters,
+        sort: this.recommendation,
+      })
+    },
   },
 }
 </script>

--- a/src/adapter/to-meilisearch-params.ts
+++ b/src/adapter/to-meilisearch-params.ts
@@ -63,9 +63,9 @@ export const adaptToMeiliSearchParams: AdaptToMeiliSearchParams = function (
     ...(facets?.length && { facetsDistribution: facets }),
     ...(attributesToCrop && { attributesToCrop }),
     ...(attributesToRetrieve && { attributesToRetrieve }),
-    ...(filter && { filter: filter }),
+    ...(filter.length && { filter: filter }),
     attributesToHighlight: attributesToHighlight || ['*'],
     limit: (!placeholderSearch && query === '') || !limit ? 0 : limit,
-    ...(sort && { sort: [sort] }),
+    ...(sort?.length && { sort: [sort] }),
   }
 }

--- a/src/adapter/to-meilisearch-params.ts
+++ b/src/adapter/to-meilisearch-params.ts
@@ -51,7 +51,7 @@ export const adaptToMeiliSearchParams: AdaptToMeiliSearchParams = function (
     filters = '',
     numericFilters = [],
   },
-  { paginationTotalHits, placeholderSearch }
+  { paginationTotalHits, placeholderSearch, sort }
 ) {
   const limit = paginationTotalHits
   const meilisearchFilters = facetFiltersToMeiliSearchFilter(facetFilters)
@@ -66,5 +66,6 @@ export const adaptToMeiliSearchParams: AdaptToMeiliSearchParams = function (
     ...(filter && { filter: filter }),
     attributesToHighlight: attributesToHighlight || ['*'],
     limit: (!placeholderSearch && query === '') || !limit ? 0 : limit,
+    ...(sort && { sort: [sort] }),
   }
 }

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -36,7 +36,6 @@ export function instantMeiliSearch(
           instantSearchParams,
           context
         )
-
         const cachedFacet = cacheFilters(msSearchParams.filter)
 
         // Executes the search with MeiliSearch

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -13,10 +13,10 @@ export function instantMeiliSearch(
     search: async function (instantSearchRequests) {
       try {
         const isSearchRequest = instantSearchRequests[0]
-        const {
-          params: instantSearchParams,
-          indexName: indexUid,
-        } = isSearchRequest
+        const { params: instantSearchParams, indexName } = isSearchRequest
+
+        // Split index name and possible sorting rules
+        const [indexUid, ...sortByArray] = indexName.split(':')
 
         const { paginationTotalHits, primaryKey, placeholderSearch } = options
         const { page, hitsPerPage } = instantSearchParams
@@ -28,6 +28,7 @@ export function instantMeiliSearch(
           placeholderSearch: placeholderSearch !== false, // true by default
           hitsPerPage: hitsPerPage === undefined ? 20 : hitsPerPage, // 20 is the MeiliSearch's default limit value. `hitsPerPage` can be changed with `InsantSearch.configure`.
           page: page || 0, // default page is 0 if none is provided
+          sort: sortByArray.join(':') || '',
         }
 
         // Adapt IS params to MeiliSearch params

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -23,6 +23,7 @@ export type IMSearchParams = Omit<
 export type ISSearchParams = Omit<IStypes.SearchParameters, 'facetFilters'> & {
   query?: string
   facetFilters?: Filter
+  sort?: string
 }
 
 export type ISSearchRequest = {
@@ -65,6 +66,7 @@ export type InstantMeiliSearchContext = {
   primaryKey: string | undefined
   client: MStypes.MeiliSearch
   placeholderSearch: boolean
+  sort?: string
 }
 
 export type FormattedHit = {


### PR DESCRIPTION
## Todo
- [x] change links in playground to running v0.22 demo
- [x] Add tests in cypress to check if sortBy works properly
- [x] Update all playgrounds by adding sortBy widget

usage example: 

```js
        <SortBy
          defaultRefinement="steam-video-games"
          items={[
            { value: 'steam-video-games', label: 'Relevant' },
            {
              value: 'steam-video-games:recommendationCount:asc',
              label: 'Least Recommended',
            },
            {
              value: 'steam-video-games:recommendationCount:desc',
              label: 'Most Recommended',
            },
            {
              value: 'steam-video-games-sort:recommendationCount:asc', // different index with different ranking rules
              label: 'Relevant Least Recommended ',
            },
            {
              value: 'steam-video-games-sort:recommendationCount:desc', // different index with different ranking rules
              label: 'Relevant Most Recommended',
            },
          ]}
        />
```

`value` attribute is  syntaxed the following way  `index:attributes:order`.

Both `query time` sorting and `indexing time sorting` are possible. Meaning, it is still possible, to add multiple indexes in the sortBy, 

Output: 
![orderexample](https://user-images.githubusercontent.com/33010418/132319635-d4121558-6dc4-4f8e-abae-c4eafeeec58d.gif)

