### PR TITLE
Support * in attributesToSnippet

### DIFF
--- a/src/adapter/search-response-adapter/highlight-adapter.ts
+++ b/src/adapter/search-response-adapter/highlight-adapter.ts
@@ -41,14 +41,14 @@ function adaptHighlight(
 ): Record<string, any> {
   // formattedHit is the `_formatted` object returned by MeiliSearch.
   // It contains all the highlighted and croped attributes
+  const toHighlightMatch = (value: any) => ({
+    value: replaceHighlightTags(value, highlightPreTag, highlightPostTag),
+  })
   return Object.keys(formattedHit).reduce((result, key) => {
-    ;(result[key] as any) = {
-      value: replaceHighlightTags(
-        formattedHit[key],
-        highlightPreTag,
-        highlightPostTag
-      ),
-    }
+    const value = formattedHit[key]
+    result[key] = Array.isArray(value)
+      ? value.map(toHighlightMatch)
+      : toHighlightMatch(value)
     return result
   }, {} as any)
 }
@@ -107,16 +107,20 @@ function adaptSnippet(
   const snippetAll = attributesToSnippet.includes('*')
   // formattedHit is the `_formatted` object returned by MeiliSearch.
   // It contains all the highlighted and croped attributes
+  const toSnippetMatch = (value: any) => ({
+    value: snippetValue(
+      value,
+      snippetEllipsisText,
+      highlightPreTag,
+      highlightPostTag
+    ),
+  })
   return (Object.keys(formattedHit) as any[]).reduce((result, key) => {
     if (snippetAll || attributesToSnippet?.includes(key)) {
-      ;(result[key] as any) = {
-        value: snippetValue(
-          formattedHit[key],
-          snippetEllipsisText,
-          highlightPreTag,
-          highlightPostTag
-        ),
-      }
+      const value = formattedHit[key]
+      result[key] = Array.isArray(value)
+        ? value.map(toSnippetMatch)
+        : toSnippetMatch(value)
     }
     return result
   }, {} as any)

--- a/tests/snippets.tests.ts
+++ b/tests/snippets.tests.ts
@@ -67,12 +67,24 @@ describe('Snippet Browser test', () => {
       '__ais-highlight__Judg__/ais-highlight__ment Night'
     )
     expect(highlighted?.overview?.value).toEqual('While')
+    expect(highlighted?.genres).toBeTruthy()
+    if (highlighted?.genres) {
+      expect(highlighted?.genres[0].value).toEqual('Action')
+      expect(highlighted?.genres[1].value).toEqual('Thriller')
+      expect(highlighted?.genres[2].value).toEqual('Crime')
+    }
     expect(highlighted?.release_date?.value).toEqual('750643200')
     expect(snippeted?.id?.value).toEqual('6')
     expect(snippeted?.title?.value).toEqual(
       '__ais-highlight__Judg__/ais-highlight__ment Night...'
     )
     expect(snippeted?.overview?.value).toEqual('While...')
+    expect(snippeted?.genres).toBeTruthy()
+    if (snippeted?.genres) {
+      expect(snippeted?.genres[0].value).toEqual('Action...')
+      expect(snippeted?.genres[1].value).toEqual('Thriller...')
+      expect(snippeted?.genres[2].value).toEqual('Crime...')
+    }
     expect(snippeted?.release_date?.value).toEqual('750643200')
   })
 


### PR DESCRIPTION
Fixes #369

Add support for `*` in `attributesToSnippet` to snippet all attributes, as documented in https://www.algolia.com/doc/api-reference/api-parameters/attributesToSnippet/#usage-notes