### PR TITLE
Fix assertions on cypress tests after meili v0.25 update

### DIFF
--- a/cypress/integration/search-ui.spec.js
+++ b/cypress/integration/search-ui.spec.js
@@ -57,14 +57,15 @@ describe(`${playground} playground test`, () => {
   })
 
   it('click on facets', () => {
+    cy.get(HIT_ITEM_CLASS).eq(0).contains('Counter-Strike')
+
     const checkbox = `.ais-RefinementList-list .ais-RefinementList-checkbox`
     cy.get(checkbox).eq(1).click()
+
     if (playground === 'react') cy.contains('1,939')
     if (playground === 'angular') cy.contains('1939')
-    cy.get(HIT_ITEM_CLASS)
-      .eq(0)
-      .contains('Safecracker: The Ultimate Puzzle Adventure')
-    cy.get(HIT_ITEM_CLASS).eq(0).contains('4.99 $')
+
+    cy.contains('Counter-Strike').should('not.exist')
   })
 
   it('Search', () => {
@@ -87,14 +88,19 @@ describe(`${playground} playground test`, () => {
   })
 
   it('Paginate Search', () => {
+    cy.get(HIT_ITEM_CLASS).eq(0).contains('Counter-Strike')
+
     if (playground === 'react') {
       cy.get('.ais-InfiniteHits-loadMore').click()
       cy.get(HIT_ITEM_CLASS).should('have.length', 12)
     } else {
-      if (playground === 'vue') cy.get('.ais-Pagination-item').eq(3).click()
-      else cy.get('.ais-Pagination-item--page').eq(1).click()
-      cy.wait(500)
-      cy.get(HIT_ITEM_CLASS).eq(0).contains('Darwinia')
+      if (playground === 'vue') {
+        cy.get('.ais-Pagination-item').eq(3).click()
+      } else {
+        cy.get('.ais-Pagination-item--page').eq(1).click()
+      }
+
+      cy.contains('Counter-Strike').should('not.exist')
     }
   })
 })


### PR DESCRIPTION
After the v0.24 -> v0.25 upgrade we could see a difference in how objects are ordered inside the list (the same behavior appeared on rails integration tests https://github.com/meilisearch/meilisearch-rails/pull/99/files#r783346153).

Beyond the fix, this test tries to rely on just checking the presence of one object to ensure the behavior is kept, I tried locally to get the first result and the first result after the action, but I failed miserably 😭.

This commit solves the problem until the first object would be affected by a future upgrade on Meili.

Hope this could help to release the v0.25 version for instant-meilisearch 🥇 