### PR TITLE
Update credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ import { instantMeiliSearch } from '@meilisearch/instant-meilisearch'
 
 const searchClient = instantMeiliSearch(
   'https://integration-demos.meilisearch.com',
-  'SEJe5jmM54f7afa09d0500b1fcc5bbeda8e4667453f5af2707c7fd62db6e4727701be0ae'
+  'q7QHwGiX841a509c8b05ef29e55f2d94c02c00635f729ccf097a734cbdf7961530f47c47'
 )
 ```
 
@@ -80,7 +80,7 @@ import { instantMeiliSearch } from '@meilisearch/instant-meilisearch'
 
 const searchClient = instantMeiliSearch(
   'https://integration-demos.meilisearch.com',
-  'SEJe5jmM54f7afa09d0500b1fcc5bbeda8e4667453f5af2707c7fd62db6e4727701be0ae',
+  'q7QHwGiX841a509c8b05ef29e55f2d94c02c00635f729ccf097a734cbdf7961530f47c47',
   {
     paginationTotalHits: 30, // default: 200.
     placeholderSearch: false, // default: true.
@@ -133,7 +133,7 @@ const search = instantsearch({
   indexName: 'steam-video-games',
   searchClient: instantMeiliSearch(
     'https://integration-demos.meilisearch.com',
-    'SEJe5jmM54f7afa09d0500b1fcc5bbeda8e4667453f5af2707c7fd62db6e4727701be0ae'
+    'q7QHwGiX841a509c8b05ef29e55f2d94c02c00635f729ccf097a734cbdf7961530f47c47'
   ),
 })
 
@@ -254,7 +254,7 @@ const search = instantsearch({
   indexName: 'instant_search',
   searchClient: instantMeiliSearch(
     'https://integration-demos.meilisearch.com',
-    'SEJe5jmM54f7afa09d0500b1fcc5bbeda8e4667453f5af2707c7fd62db6e4727701be0ae',
+    'q7QHwGiX841a509c8b05ef29e55f2d94c02c00635f729ccf097a734cbdf7961530f47c47',
     {
       // ... InstantMeiliSearch options
     }

--- a/playgrounds/angular/src/app/app.component.ts
+++ b/playgrounds/angular/src/app/app.component.ts
@@ -3,7 +3,7 @@ import { instantMeiliSearch } from '../../../../src'
 
 const searchClient = instantMeiliSearch(
   'https://integration-demos.meilisearch.com',
-  'SEJe5jmM54f7afa09d0500b1fcc5bbeda8e4667453f5af2707c7fd62db6e4727701be0ae'
+  'q7QHwGiX841a509c8b05ef29e55f2d94c02c00635f729ccf097a734cbdf7961530f47c47'
 )
 
 @Component({

--- a/playgrounds/geo-javascript/src/app.js
+++ b/playgrounds/geo-javascript/src/app.js
@@ -10,7 +10,7 @@ injectScript(
       indexName: 'world_cities',
       searchClient: instantMeiliSearch(
         'https://integration-demos.meilisearch.com',
-        'SEJe5jmM54f7afa09d0500b1fcc5bbeda8e4667453f5af2707c7fd62db6e4727701be0ae',
+        'q7QHwGiX841a509c8b05ef29e55f2d94c02c00635f729ccf097a734cbdf7961530f47c47',
         {
           limitPerRequest: 20,
         }

--- a/playgrounds/html/public/index.html
+++ b/playgrounds/html/public/index.html
@@ -28,7 +28,7 @@
       indexName: "steam-video-games",
       searchClient: instantMeiliSearch(
         "https://integration-demos.meilisearch.com",
-        "SEJe5jmM54f7afa09d0500b1fcc5bbeda8e4667453f5af2707c7fd62db6e4727701be0ae"
+        "q7QHwGiX841a509c8b05ef29e55f2d94c02c00635f729ccf097a734cbdf7961530f47c47"
       )
     });
     search.addWidgets([

--- a/playgrounds/javascript/src/app.js
+++ b/playgrounds/javascript/src/app.js
@@ -4,7 +4,7 @@ const search = instantsearch({
   indexName: 'steam-video-games',
   searchClient: instantMeiliSearch(
     'https://integration-demos.meilisearch.com',
-    'SEJe5jmM54f7afa09d0500b1fcc5bbeda8e4667453f5af2707c7fd62db6e4727701be0ae',
+    'q7QHwGiX841a509c8b05ef29e55f2d94c02c00635f729ccf097a734cbdf7961530f47c47',
     {
       limitPerRequest: 30,
     }

--- a/playgrounds/react/src/App.js
+++ b/playgrounds/react/src/App.js
@@ -18,7 +18,7 @@ import { instantMeiliSearch } from '../../../src/index'
 
 const searchClient = instantMeiliSearch(
   'https://integration-demos.meilisearch.com',
-  'SEJe5jmM54f7afa09d0500b1fcc5bbeda8e4667453f5af2707c7fd62db6e4727701be0ae',
+  'q7QHwGiX841a509c8b05ef29e55f2d94c02c00635f729ccf097a734cbdf7961530f47c47',
   {
     paginationTotalHits: 60,
     primaryKey: 'id',

--- a/playgrounds/vue/src/App.vue
+++ b/playgrounds/vue/src/App.vue
@@ -85,7 +85,7 @@ export default {
       recommendation: '',
       searchClient: instantMeiliSearch(
         'https://integration-demos.meilisearch.com',
-        'SEJe5jmM54f7afa09d0500b1fcc5bbeda8e4667453f5af2707c7fd62db6e4727701be0ae'
+        'q7QHwGiX841a509c8b05ef29e55f2d94c02c00635f729ccf097a734cbdf7961530f47c47'
       ),
     }
   },


### PR DESCRIPTION
Update with new default search key
I've updated the instance to use MeiliSearch v0.25.2, and I used a dump coming from v0.24.0, so the API keys were reset.

To merge as soon as possible to avoid frictions for contributors using the playground and for users trying the README :)