### PR TITLE
Fix tests related to changes in placeholder hits order resolver

### DIFF
--- a/tests/configure.attributes-to-retrieve.tests.ts
+++ b/tests/configure.attributes-to-retrieve.tests.ts
@@ -54,7 +54,7 @@ describe('Instant Meilisearch Browser test', () => {
     expect(hit.title).not.toBeDefined()
   })
 
-  test('Test attributesToRetrieve on one non existing attribute', async () => {
+  test.skip('Test attributesToRetrieve on one non existing attribute', async () => {
     const response = await searchClient.search([
       {
         indexName: 'movies',
@@ -75,7 +75,7 @@ describe('Instant Meilisearch Browser test', () => {
     expect(hit._highlightResult?.title).toBeDefined()
   })
 
-  test('Test attributesToRetrieve on one existing attribute', async () => {
+  test.skip('Test attributesToRetrieve on one existing attribute', async () => {
     const response = await searchClient.search([
       {
         indexName: 'movies',

--- a/tests/configure.attributes-to-retrieve.tests.ts
+++ b/tests/configure.attributes-to-retrieve.tests.ts
@@ -54,7 +54,7 @@ describe('Instant Meilisearch Browser test', () => {
     expect(hit.title).not.toBeDefined()
   })
 
-  test.skip('Test attributesToRetrieve on one non existing attribute', async () => {
+  test('Test attributesToRetrieve on one non existing attribute', async () => {
     const response = await searchClient.search([
       {
         indexName: 'movies',
@@ -75,7 +75,7 @@ describe('Instant Meilisearch Browser test', () => {
     expect(hit._highlightResult?.title).toBeDefined()
   })
 
-  test.skip('Test attributesToRetrieve on one existing attribute', async () => {
+  test('Test attributesToRetrieve on one existing attribute', async () => {
     const response = await searchClient.search([
       {
         indexName: 'movies',

--- a/tests/filter.tests.ts
+++ b/tests/filter.tests.ts
@@ -84,7 +84,7 @@ describe('Instant Meilisearch Browser test', () => {
         indexName: 'movies',
         params: {
           query: '',
-          facetFilters: ['genres:Comedy', 'genres:Crime'],
+          facetFilters: [['genres:Comedy'], ['genres:Crime']],
         },
       },
     ])
@@ -104,6 +104,7 @@ describe('Instant Meilisearch Browser test', () => {
       },
     ])
     const hits = response.results[0].hits
+
     expect(hits.length).toEqual(2)
     expect(hits[0].title).toEqual('Ariel')
   })
@@ -121,7 +122,7 @@ describe('Instant Meilisearch Browser test', () => {
     expect(hits[0].title).toEqual('Judgment Night')
   })
 
-  test('Test multiple nested on filter without a query', async () => {
+  test('Test multiple nested array in filter without a query', async () => {
     const params = {
       indexName: 'movies',
       params: {
@@ -131,7 +132,7 @@ describe('Instant Meilisearch Browser test', () => {
     }
     const response = await searchClient.search<Movies>([params])
     const hits = response.results[0].hits
-    expect(hits[0].title).toEqual('Kill Bill: Vol. 1')
+    expect(hits[0].title).toEqual('Judgment Night')
   })
 
   test('Test multiple nested arrays on filter with a query', async () => {

--- a/tests/filter.tests.ts
+++ b/tests/filter.tests.ts
@@ -84,7 +84,7 @@ describe('Instant Meilisearch Browser test', () => {
         indexName: 'movies',
         params: {
           query: '',
-          facetFilters: [['genres:Comedy'], ['genres:Crime']],
+          facetFilters: ['genres:Comedy', 'genres:Crime'],
         },
       },
     ])

--- a/tests/highlight.tests.ts
+++ b/tests/highlight.tests.ts
@@ -86,8 +86,8 @@ describe('Highlight Browser test', () => {
 
     const highlightedHit = response.results[0].hits[0]._highlightResult
     if (highlightedHit?.genres) {
-      expect(highlightedHit?.genres[0]?.value).toEqual('Adventure')
-      expect(highlightedHit?.genres[1]?.value).toEqual('Action')
+      expect(highlightedHit?.genres[0]?.value).toEqual('Drama')
+      expect(highlightedHit?.genres[1]?.value).toEqual('Crime')
     }
   })
 

--- a/tests/pagination.tests.ts
+++ b/tests/pagination.tests.ts
@@ -54,7 +54,7 @@ describe('Pagination browser test', () => {
       {
         indexName: 'movies',
         params: {
-          query: 'Ariel',
+          query: '',
           hitsPerPage: 1,
           page: 1,
         },

--- a/tests/pagination.tests.ts
+++ b/tests/pagination.tests.ts
@@ -31,7 +31,6 @@ describe('Pagination browser test', () => {
     ])
     const hits = response.results[0].hits
     expect(hits.length).toBe(1)
-    expect(hits[0]?.title).toBe('Star Wars')
   })
 
   test('Test 1 hitsPerPage w/ page 0 ', async () => {
@@ -48,7 +47,6 @@ describe('Pagination browser test', () => {
     const hits = response.results[0].hits
 
     expect(hits.length).toBe(1)
-    expect(hits[0].title).toBe('Star Wars')
   })
 
   test('Test 1 hitsPerPage w/ page 1 ', async () => {
@@ -56,7 +54,7 @@ describe('Pagination browser test', () => {
       {
         indexName: 'movies',
         params: {
-          query: '',
+          query: 'Ariel',
           hitsPerPage: 1,
           page: 1,
         },
@@ -64,7 +62,6 @@ describe('Pagination browser test', () => {
     ])
     const hits = response.results[0].hits
     expect(hits.length).toBe(1)
-    expect(hits[0].title).toBe('Ariel')
   })
 
   test('Test 100 hitsPerPage w/ page 1 ', async () => {

--- a/tests/snippets.tests.ts
+++ b/tests/snippets.tests.ts
@@ -324,6 +324,6 @@ test('Test attributes to snippet on value smaller than the snippet size', async 
   const hit = response.results[0].hits[0]._snippetResult
 
   if (hit?.overview) {
-    expect(hit?.title?.value).toEqual('Star Wars')
+    expect(hit?.title?.value).toEqual('Ariel')
   }
 })


### PR DESCRIPTION
Changes have been made on the order in which the documents are ordered by default. Tests have been updated accordingly

See https://github.com/meilisearch/meilisearch/pull/2298 for more information
