### PR TITLE
Update version for the next release (v0.7.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meilisearch/instant-meilisearch",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": false,
   "description": "The search client to use Meilisearch with InstantSearch.",
   "scripts": {


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v0.27.0 :tada:
Check out the changelog of [Meilisearch v0.27.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.27.0) for more information on the changes.

## 🚀 Enhancements

- Add highlight prefix suffix tags #739
- Add crop marker support #738

Thanks again to @bidoubiwa and @mmachatschek! 🎉
