### PR TITLE
Update search route request and response parameters naming v0.28.x

### DIFF
--- a/src/adapter/search-request-adapter/filters.ts
+++ b/src/adapter/search-request-adapter/filters.ts
@@ -62,10 +62,10 @@ export function getFacetsFromFilter(filters?: Filter): FacetsCache {
 }
 
 function getFacetsFromDefaultDistribution(
-  facetsDistribution: FacetsDistribution
+  facetDistribution: FacetsDistribution
 ): FacetsCache {
-  return Object.keys(facetsDistribution).reduce((cache: any, facet) => {
-    const facetValues = Object.keys(facetsDistribution[facet])
+  return Object.keys(facetDistribution).reduce((cache: any, facet) => {
+    const facetValues = Object.keys(facetDistribution[facet])
     return {
       ...cache,
       [facet]: facetValues,
@@ -91,8 +91,8 @@ export function extractFacets(
 }
 
 /**
- * Assign missing filters to facetsDistribution.
- * All facet passed as filter should appear in the facetsDistribution.
+ * Assign missing filters to facetDistribution.
+ * All facets passed as filter should appear in the facetDistribution.
  * If not present, the facet is added with 0 as value.
  *
  *

--- a/src/adapter/search-request-adapter/search-params-adapter.ts
+++ b/src/adapter/search-request-adapter/search-params-adapter.ts
@@ -22,7 +22,7 @@ export function adaptSearchParams(
   // Facets
   const facets = searchContext?.facets
   if (facets?.length) {
-    meiliSearchParams.facetsDistribution = facets
+    meiliSearchParams.facets = facets
   }
 
   // Attributes To Crop

--- a/src/adapter/search-request-adapter/search-resolver.ts
+++ b/src/adapter/search-request-adapter/search-resolver.ts
@@ -10,11 +10,10 @@ import { addMissingFacets, extractFacets } from './filters'
 const emptySearch: MeiliSearchResponse<Record<string, any>> = {
   hits: [],
   query: '',
-  facetsDistribution: {},
+  facetDistribution: {},
   limit: 0,
   offset: 0,
-  exhaustiveNbHits: false,
-  nbHits: 0,
+  estimatedTotalHits: 0,
   processingTimeMs: 0,
 }
 
@@ -69,10 +68,10 @@ export function SearchResolver(cache: SearchCacheInterface) {
         .index(searchContext.indexUid)
         .search(searchContext.query, searchParams)
 
-      // Add missing facets back into facetsDistribution
-      searchResponse.facetsDistribution = addMissingFacets(
+      // Add missing facets back into facetDistribution
+      searchResponse.facetDistribution = addMissingFacets(
         facetsCache,
-        searchResponse.facetsDistribution
+        searchResponse.facetDistribution
       )
 
       // Cache response

--- a/src/adapter/search-response-adapter/hits-adapter.ts
+++ b/src/adapter/search-response-adapter/hits-adapter.ts
@@ -21,7 +21,11 @@ export function adaptHits(
   let adaptedHits = paginatedHits.map((hit: Record<string, any>) => {
     // Creates Hit object compliant with InstantSearch
     if (Object.keys(hit).length > 0) {
-      const { _formatted: formattedHit, _matchesInfo, ...documentFields } = hit
+      const {
+        _formatted: formattedHit,
+        _matchesPosition,
+        ...documentFields
+      } = hit
 
       const adaptedHit: Record<string, any> = Object.assign(
         documentFields,

--- a/src/adapter/search-response-adapter/search-response-adapter.ts
+++ b/src/adapter/search-response-adapter/search-response-adapter.ts
@@ -21,13 +21,8 @@ export function adaptSearchResponse<T>(
 ): { results: Array<AlgoliaSearchResponse<T>> } {
   const searchResponseOptionals: Record<string, any> = {}
 
-  const facets = searchResponse.facetsDistribution
+  const facets = searchResponse.facetDistribution
   const { pagination } = searchContext
-
-  const exhaustiveFacetsCount = searchResponse?.exhaustiveFacetsCount
-  if (exhaustiveFacetsCount) {
-    searchResponseOptionals.exhaustiveFacetsCount = exhaustiveFacetsCount
-  }
 
   const nbPages = ceiledDivision(
     searchResponse.hits.length,
@@ -35,8 +30,7 @@ export function adaptSearchResponse<T>(
   )
   const hits = adaptHits(searchResponse.hits, searchContext, pagination)
 
-  const exhaustiveNbHits = searchResponse.exhaustiveNbHits
-  const nbHits = searchResponse.nbHits
+  const estimatedTotalHits = searchResponse.estimatedTotalHits
   const processingTimeMs = searchResponse.processingTimeMs
   const query = searchResponse.query
 
@@ -49,12 +43,12 @@ export function adaptSearchResponse<T>(
     page,
     facets,
     nbPages,
-    exhaustiveNbHits,
-    nbHits,
+    nbHits: estimatedTotalHits,
     processingTimeMS: processingTimeMs,
     query,
     hits,
     params: '',
+    exhaustiveNbHits: false,
     ...searchResponseOptionals,
   }
   return {

--- a/src/cache/__tests__/assets/utils.ts
+++ b/src/cache/__tests__/assets/utils.ts
@@ -4,6 +4,6 @@ export const searchResponse = {
   offset: 0,
   limit: 0,
   processingTimeMs: 0,
-  nbHits: 0,
+  estimatedTotalHits: 0,
   exhaustiveNbHits: false,
 }

--- a/src/cache/first-facets-distribution.ts
+++ b/src/cache/first-facets-distribution.ts
@@ -1,6 +1,6 @@
 import { FacetsDistribution } from '../types'
 
-export function cacheFirstFacetsDistribution(
+export function cacheFirstFacetDistribution(
   defaultFacetDistribution: FacetsDistribution,
   searchResponse: any
 ): FacetsDistribution {
@@ -8,7 +8,7 @@ export function cacheFirstFacetsDistribution(
     searchResponse.query === '' &&
     Object.keys(defaultFacetDistribution).length === 0
   ) {
-    return searchResponse.facetsDistribution
+    return searchResponse.facetDistribution
   }
   return defaultFacetDistribution
 }

--- a/src/client/instant-meilisearch-client.ts
+++ b/src/client/instant-meilisearch-client.ts
@@ -12,7 +12,7 @@ import {
   SearchResolver,
 } from '../adapter'
 import { createSearchContext } from '../contexts'
-import { SearchCache, cacheFirstFacetsDistribution } from '../cache/'
+import { SearchCache, cacheFirstFacetDistribution } from '../cache/'
 
 /**
  * Instanciate SearchClient required by instantsearch.js.
@@ -60,9 +60,9 @@ export function instantMeiliSearch(
         )
 
         // Cache first facets distribution of the instantMeilisearch instance
-        // Needed to add in the facetsDistribution the fields that were not returned
+        // Needed to add in the facetDistribution the fields that were not returned
         // When the user sets `keepZeroFacets` to true.
-        defaultFacetDistribution = cacheFirstFacetsDistribution(
+        defaultFacetDistribution = cacheFirstFacetDistribution(
           defaultFacetDistribution,
           searchResponse
         )

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,5 +1,4 @@
 import type {
-  MeiliSearch,
   SearchResponse as MeiliSearchResponse,
   FacetsDistribution,
 } from 'meilisearch'

--- a/tests/configure.attributes-to-retrieve.tests.ts
+++ b/tests/configure.attributes-to-retrieve.tests.ts
@@ -8,12 +8,12 @@ import {
 describe('Instant Meilisearch Browser test', () => {
   beforeAll(async () => {
     const deleteTask = await meilisearchClient.deleteIndex('movies')
-    await meilisearchClient.waitForTask(deleteTask.uid)
+    await meilisearchClient.waitForTask(deleteTask.taskUid)
 
     const documentsTask = await meilisearchClient
       .index('movies')
       .addDocuments(dataset)
-    await meilisearchClient.index('movies').waitForTask(documentsTask.uid)
+    await meilisearchClient.index('movies').waitForTask(documentsTask.taskUid)
   })
 
   test('Test attributesToRetrieve on no attributes', async () => {

--- a/tests/env/react/setup.js
+++ b/tests/env/react/setup.js
@@ -244,6 +244,6 @@ const { MeiliSearch } = require('meilisearch')
 
   const response = await index.addDocuments(dataset)
 
-  const task = await client.waitForTask(response.uid)
+  const task = await client.waitForTask(response.taskUid)
   console.log(task)
 })()

--- a/tests/facets-distribution.tests.ts
+++ b/tests/facets-distribution.tests.ts
@@ -3,17 +3,17 @@ import { searchClient, dataset, meilisearchClient } from './assets/utils'
 describe('Instant Meilisearch Browser test', () => {
   beforeAll(async () => {
     const deleteTask = await meilisearchClient.deleteIndex('movies')
-    await meilisearchClient.waitForTask(deleteTask.uid)
+    await meilisearchClient.waitForTask(deleteTask.taskUid)
     await meilisearchClient
       .index('movies')
       .updateFilterableAttributes(['genres'])
     const documentsTask = await meilisearchClient
       .index('movies')
       .addDocuments(dataset)
-    await meilisearchClient.index('movies').waitForTask(documentsTask.uid)
+    await meilisearchClient.index('movies').waitForTask(documentsTask.taskUid)
   })
 
-  test('Test empty array on facetsDistribution', async () => {
+  test('Test empty array on facetDistribution', async () => {
     const response = await searchClient.search([
       {
         indexName: 'movies',
@@ -26,7 +26,7 @@ describe('Instant Meilisearch Browser test', () => {
     expect(response.results[0].facets?.genres).toEqual(undefined)
   })
 
-  test('Test one facet on facetsDistribution', async () => {
+  test('Test one facet on facetDistribution', async () => {
     const response = await searchClient.search([
       {
         indexName: 'movies',

--- a/tests/filter.tests.ts
+++ b/tests/filter.tests.ts
@@ -8,14 +8,14 @@ import {
 describe('Instant Meilisearch Browser test', () => {
   beforeAll(async () => {
     const deleteTask = await meilisearchClient.deleteIndex('movies')
-    await meilisearchClient.waitForTask(deleteTask.uid)
+    await meilisearchClient.waitForTask(deleteTask.taskUid)
     await meilisearchClient
       .index('movies')
       .updateFilterableAttributes(['genres', 'title'])
     const documentsTask = await meilisearchClient
       .index('movies')
       .addDocuments(dataset)
-    await meilisearchClient.index('movies').waitForTask(documentsTask.uid)
+    await meilisearchClient.index('movies').waitForTask(documentsTask.taskUid)
   })
 
   test('Test one string facet on filter without a query', async () => {

--- a/tests/geosearch.tests.ts
+++ b/tests/geosearch.tests.ts
@@ -8,7 +8,7 @@ import {
 describe('Instant Meilisearch Browser test', () => {
   beforeAll(async () => {
     const deleteTask = await meilisearchClient.deleteIndex('geotest')
-    await meilisearchClient.waitForTask(deleteTask.uid)
+    await meilisearchClient.waitForTask(deleteTask.taskUid)
     await meilisearchClient
       .index('geotest')
       .updateFilterableAttributes(['_geo'])
@@ -16,7 +16,7 @@ describe('Instant Meilisearch Browser test', () => {
     const documentsTask = await meilisearchClient
       .index('geotest')
       .addDocuments(geoDataset)
-    await meilisearchClient.index('movies').waitForTask(documentsTask.uid)
+    await meilisearchClient.index('movies').waitForTask(documentsTask.taskUid)
   })
 
   test('Test aroundRadius and aroundLatLng in geo search', async () => {

--- a/tests/highlight.tests.ts
+++ b/tests/highlight.tests.ts
@@ -8,14 +8,14 @@ import {
 describe('Highlight Browser test', () => {
   beforeAll(async () => {
     const deleteTask = await meilisearchClient.deleteIndex('movies')
-    await meilisearchClient.waitForTask(deleteTask.uid)
+    await meilisearchClient.waitForTask(deleteTask.taskUid)
     await meilisearchClient
       .index('movies')
       .updateFilterableAttributes(['genres'])
     const documentsTask = await meilisearchClient
       .index('movies')
       .addDocuments(dataset)
-    await meilisearchClient.index('movies').waitForTask(documentsTask.uid)
+    await meilisearchClient.index('movies').waitForTask(documentsTask.taskUid)
   })
 
   test('Test one attributesToHighlight on wrong attribute placeholder', async () => {

--- a/tests/pagination.tests.ts
+++ b/tests/pagination.tests.ts
@@ -9,14 +9,14 @@ import {
 describe('Pagination browser test', () => {
   beforeAll(async () => {
     const deleteTask = await meilisearchClient.deleteIndex('movies')
-    await meilisearchClient.waitForTask(deleteTask.uid)
+    await meilisearchClient.waitForTask(deleteTask.taskUid)
     await meilisearchClient
       .index('movies')
       .updateFilterableAttributes(['genres'])
     const documentsTask = await meilisearchClient
       .index('movies')
       .addDocuments(dataset)
-    await meilisearchClient.index('movies').waitForTask(documentsTask.uid)
+    await meilisearchClient.index('movies').waitForTask(documentsTask.taskUid)
   })
 
   test('Test 1 hitsPerPage', async () => {

--- a/tests/placeholder-search.tests.ts
+++ b/tests/placeholder-search.tests.ts
@@ -9,14 +9,14 @@ import {
 describe('Pagination browser test', () => {
   beforeAll(async () => {
     const deleteTask = await meilisearchClient.deleteIndex('movies')
-    await meilisearchClient.waitForTask(deleteTask.uid)
+    await meilisearchClient.waitForTask(deleteTask.taskUid)
     await meilisearchClient
       .index('movies')
       .updateFilterableAttributes(['genres'])
     const documentsTask = await meilisearchClient
       .index('movies')
       .addDocuments(dataset)
-    await meilisearchClient.index('movies').waitForTask(documentsTask.uid)
+    await meilisearchClient.index('movies').waitForTask(documentsTask.taskUid)
   })
 
   test('Test placeholdersearch set to false', async () => {

--- a/tests/search-resolver.tests.ts
+++ b/tests/search-resolver.tests.ts
@@ -11,7 +11,7 @@ export const searchResponse = {
   offset: 0,
   limit: 0,
   processingTimeMs: 0,
-  nbHits: 0,
+  estimatedTotalHits: 0,
   exhaustiveNbHits: false,
 }
 

--- a/tests/snippets.tests.ts
+++ b/tests/snippets.tests.ts
@@ -8,14 +8,14 @@ import {
 describe('Snippet Browser test', () => {
   beforeAll(async () => {
     const deleteTask = await meilisearchClient.deleteIndex('movies')
-    await meilisearchClient.waitForTask(deleteTask.uid)
+    await meilisearchClient.waitForTask(deleteTask.taskUid)
     await meilisearchClient
       .index('movies')
       .updateFilterableAttributes(['genres'])
     const documentsTask = await meilisearchClient
       .index('movies')
       .addDocuments(dataset)
-    await meilisearchClient.index('movies').waitForTask(documentsTask.uid)
+    await meilisearchClient.index('movies').waitForTask(documentsTask.taskUid)
   })
 
   test('Test one attributesToSnippet on placeholder without a snippetEllipsisText', async () => {


### PR DESCRIPTION
Applies the breaking changes from the new version of meilisearch-js see [`v0.27.0-beta.1` release](https://github.com/meilisearch/meilisearch-js/releases/tag/v0.27.0-beta.1)

⚠️ The `FacetsDistribution` type provided by `meilisearch-js` should be updated to `FacetDistribution`. This change will be present in the next beta version of the package

There are no breaking changes! 