### PR TITLE
Remove warning that `or` operator does not work in react

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,7 +656,7 @@ The `refinementList` widget is one of the most common widgets you can find in a 
 
 - ✅ container: The CSS Selector or HTMLElement to insert the refinements. _required_
 - ✅ attribute: The facet to display _required_
-- ✅ operator: How to apply facets, `and` or `or` (`and` is the default value). ⚠️ Does not seem to work on react-instantsearch.
+- ✅ operator: How to apply facets, `and` or `or` (`and` is the default value).
 - ✅ limit: How many facet values to retrieve.
 - ✅ showMore: Whether to display a button that expands the number of items.
 - ✅ showMoreLimit: The maximum number of displayed items. Does not work when showMoreLimit > limit.


### PR DESCRIPTION
After checking again, the `or` operator seems to be working correctly in a react environment