### PR TITLE
Update search key in playgrounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ import { instantMeiliSearch } from '@meilisearch/instant-meilisearch'
 
 const searchClient = instantMeiliSearch(
   'https://integration-demos.meilisearch.com', // Host
-  'q7QHwGiX841a509c8b05ef29e55f2d94c02c00635f729ccf097a734cbdf7961530f47c47' // API key
+  '99d1e034ed32eb569f9edc27962cccf90b736e4c5a70f7f5e76b9fab54d6a185' // API key
 )
 ```
 
@@ -91,7 +91,7 @@ import { instantMeiliSearch } from '@meilisearch/instant-meilisearch'
 
 const searchClient = instantMeiliSearch(
   'https://integration-demos.meilisearch.com',
-  'q7QHwGiX841a509c8b05ef29e55f2d94c02c00635f729ccf097a734cbdf7961530f47c47',
+  '99d1e034ed32eb569f9edc27962cccf90b736e4c5a70f7f5e76b9fab54d6a185',
   {
     paginationTotalHits: 30, // default: 200.
     placeholderSearch: false, // default: true.
@@ -205,7 +205,7 @@ const search = instantsearch({
   indexName: 'steam-video-games',
   searchClient: instantMeiliSearch(
     'https://integration-demos.meilisearch.com',
-    'q7QHwGiX841a509c8b05ef29e55f2d94c02c00635f729ccf097a734cbdf7961530f47c47'
+    '99d1e034ed32eb569f9edc27962cccf90b736e4c5a70f7f5e76b9fab54d6a185'
   ),
 })
 
@@ -326,7 +326,7 @@ const search = instantsearch({
   indexName: 'instant_search',
   searchClient: instantMeiliSearch(
     'https://integration-demos.meilisearch.com',
-    'q7QHwGiX841a509c8b05ef29e55f2d94c02c00635f729ccf097a734cbdf7961530f47c47',
+    '99d1e034ed32eb569f9edc27962cccf90b736e4c5a70f7f5e76b9fab54d6a185',
     {
       // ... InstantMeiliSearch options
     }

--- a/playgrounds/angular/src/app/app.component.ts
+++ b/playgrounds/angular/src/app/app.component.ts
@@ -3,7 +3,7 @@ import { instantMeiliSearch } from '../../../../src'
 
 const searchClient = instantMeiliSearch(
   'https://integration-demos.meilisearch.com',
-  'q7QHwGiX841a509c8b05ef29e55f2d94c02c00635f729ccf097a734cbdf7961530f47c47'
+  '99d1e034ed32eb569f9edc27962cccf90b736e4c5a70f7f5e76b9fab54d6a185'
 )
 
 @Component({

--- a/playgrounds/geo-javascript/src/app.js
+++ b/playgrounds/geo-javascript/src/app.js
@@ -10,7 +10,7 @@ injectScript(
       indexName: 'world_cities',
       searchClient: instantMeiliSearch(
         'https://integration-demos.meilisearch.com',
-        'q7QHwGiX841a509c8b05ef29e55f2d94c02c00635f729ccf097a734cbdf7961530f47c47',
+        '99d1e034ed32eb569f9edc27962cccf90b736e4c5a70f7f5e76b9fab54d6a185',
         {
           limitPerRequest: 20,
         }

--- a/playgrounds/html/public/index.html
+++ b/playgrounds/html/public/index.html
@@ -28,7 +28,7 @@
       indexName: "steam-video-games",
       searchClient: instantMeiliSearch(
         "https://integration-demos.meilisearch.com",
-        "q7QHwGiX841a509c8b05ef29e55f2d94c02c00635f729ccf097a734cbdf7961530f47c47"
+        "99d1e034ed32eb569f9edc27962cccf90b736e4c5a70f7f5e76b9fab54d6a185"
       )
     });
     search.addWidgets([

--- a/playgrounds/javascript/src/app.js
+++ b/playgrounds/javascript/src/app.js
@@ -4,7 +4,7 @@ const search = instantsearch({
   indexName: 'steam-video-games',
   searchClient: instantMeiliSearch(
     'https://integration-demos.meilisearch.com',
-    'q7QHwGiX841a509c8b05ef29e55f2d94c02c00635f729ccf097a734cbdf7961530f47c47',
+    '99d1e034ed32eb569f9edc27962cccf90b736e4c5a70f7f5e76b9fab54d6a185',
     {
       limitPerRequest: 30,
     }

--- a/playgrounds/react/src/App.js
+++ b/playgrounds/react/src/App.js
@@ -18,7 +18,7 @@ import { instantMeiliSearch } from '../../../src/index'
 
 const searchClient = instantMeiliSearch(
   'https://integration-demos.meilisearch.com',
-  'q7QHwGiX841a509c8b05ef29e55f2d94c02c00635f729ccf097a734cbdf7961530f47c47',
+  '99d1e034ed32eb569f9edc27962cccf90b736e4c5a70f7f5e76b9fab54d6a185',
   {
     paginationTotalHits: 60,
     primaryKey: 'id',

--- a/playgrounds/vue/src/App.vue
+++ b/playgrounds/vue/src/App.vue
@@ -85,7 +85,7 @@ export default {
       recommendation: '',
       searchClient: instantMeiliSearch(
         'https://integration-demos.meilisearch.com',
-        'q7QHwGiX841a509c8b05ef29e55f2d94c02c00635f729ccf097a734cbdf7961530f47c47'
+        '99d1e034ed32eb569f9edc27962cccf90b736e4c5a70f7f5e76b9fab54d6a185'
       ),
     }
   },


### PR DESCRIPTION
With the upgrade of versions in the [integration Meilisearch instance](https://integration-demos.meilisearch.com) the keys have been regenerated and thus are not working anymore.

This time the key has been created with a specific uid. On next updates of the Meilisearch server instead of changing the API key we just need to recreate the key in the new instance and the key will still be working.

