### PR TITLE
Create new publish CI for beta versions

### DIFF
--- a/.github/scripts/check-tag-format.sh
+++ b/.github/scripts/check-tag-format.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# Checking if current tag matches the required formating
+is_pre_release=$1
+current_tag=$(echo $GITHUB_REF | cut -d '/' -f 3 | tr -d ' ',v)
+
+if [ $is_pre_release = false ]; then
+  # Works with the format vX.X.X
+  #
+  # Example of correct format:
+  # v0.1.0
+  echo "$current_tag" | grep -E "[0-9]*\.[0-9]*\.[0-9]*$"
+  if [ $? != 0 ]; then
+    echo "Error: Your tag: $current_tag is wrongly formatted."
+    echo 'Please refer to the contributing guide for help.'
+    exit 1
+  fi
+  exit 0
+elif [ $is_pre_release = true ]; then
+  # Works with the format vX.X.X-xxx-beta.X
+  # none or multiple -xxx are valid
+  #
+  # Examples of correct format:
+  # v0.1.0-beta.0
+  # v0.1.0-xxx-beta.0
+  # v0.1.0-xxx-xxx-beta.0
+  echo "$current_tag" | grep -E "[0-9]*\.[0-9]*\.[0-9]*-([a-z]*-)*beta\.[0-9]*$"
+
+  if [ $? != 0 ]; then
+    echo "Error: Your beta tag: $current_tag is wrongly formatted."
+    echo 'Please refer to the contributing guide for help.'
+    exit 1
+  fi
+  exit 0
+fi
+
+exit 0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,17 +14,19 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - name: Check release validity
         run: sh .github/scripts/check-release.sh
+      - name: Check tag format
+        run: sh .github/scripts/check-tag-format.sh "${{ github.event.release.prerelease }}"
       - name: Install dependencies
         run: yarn install
       - name: Build instant-meilisearch
         run: yarn build
       - name: Publish with latest tag
-        if: "!github.event.release.prerelease"
+        if: "!github.event.release.prerelease && !contains(github.ref, 'beta')"
         run: npm publish .
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Publish with beta tag
-        if: "github.event.release.prerelease"
+        if: "github.event.release.prerelease && contains(github.ref, 'beta')"
         run: npm publish . --tag beta
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,16 +159,25 @@ If you don't have the access to do it, please request it internally.
 
 Here are the steps to release a beta version of this package:
 
-- Create a new branch originating the branch containing the "beta" changes. For example, if during the Meilisearch pre-release, create a branch originating `bump-meilisearch-v*.*.*`.<br>
-`vX.X.X` is the next version of the package, NOT the version of Meilisearch!
+- Create a new branch containing the "beta" changes with the following format `xxx-beta` where `xxx` explains the context.
 
-```bash
-git checkout bump-meilisearch-v*.*.*
-git pull origin bump-meilisearch-v*.*.*
-git checkout -b vX.X.X-beta.0
-```
+  For example:
+    - When implementing a beta feature, create a branch `my-feature-beta` where you implement the feature.
+      ```bash
+        git checkout -b my-feature-beta
+      ```
+    - During the Meilisearch pre-release, create a branch originating from `bump-meilisearch-v*.*.*` named `bump-meilisearch-v*.*.*-beta`. <br>
+    `v*.*.*` is the next version of the package, NOT the version of Meilisearch!
 
-- Change the version in `package.json` by `vX.X.X-beta.0` and commit it to the `vX.X.X-beta.0` branch
+      ```bash
+      git checkout bump-meilisearch-v*.*.*
+      git pull origin bump-meilisearch-v*.*.*
+      git checkout -b bump-meilisearch-v*.*.*-beta
+      ```
+
+- Change the version in `package.json` with `*.*.*-xxx-beta.0` and commit it to the `v*.*.*-beta` branch. None or multiple `-xxx`are valid. Examples:
+  - `v*.*.*-my-feature-beta.0`
+  - `v*.*.*-beta.0`
 
 - Go to the [GitHub interface for releasing](https://github.com/meilisearch/instant-meilisearch/releases): on this page, click on `Draft a new release`.
 


### PR DESCRIPTION
To be able to create beta releases on different subjects: `bumps`, `features`, etc.. we needed to provide a better suited CI.

This CI also checks if the tag well formated to ensure we do not publish a version that does not follow the naming convention.

The workflow has been tested on a private directory and seems to work correctly.
