### PR TITLE
Use needs context in beta CI to communicate meilisearch image version

### DIFF
--- a/.github/workflows/beta-tests.yml
+++ b/.github/workflows/beta-tests.yml
@@ -9,8 +9,21 @@ on:
     branches: ['!bump-meilisearch-v*.*.*-beta', '**-beta']
 
 jobs:
+  grep-docker-version:
+    runs-on: ubuntu-latest
+    outputs:
+      docker-version: ${{ steps.grep-step.outputs.version }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Grep docker beta version of Meilisearch
+        id: grep-step
+        run: |
+          MEILISEARCH_IMAGE=$(sh .github/scripts/beta-docker-version.sh)
+          echo $MEILISEARCH_IMAGE
+          echo ::set-output name=version::$MEILISEARCH_IMAGE
   cypress-run:
     runs-on: ubuntu-latest
+    needs: ['grep-docker-version']
     # Only test on Google Chrome
     container: cypress/browsers:node12.18.3-chrome87-ff82
     steps:
@@ -26,12 +39,8 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '14.x'
-      - name: Grep beta version of Meilisearch
-        run: echo "MEILISEARCH_IMAGE=$(sh .github/scripts/beta-docker-version.sh)" >> $GITHUB_ENV
-      - name: Try version script
-        run: sh .github/scripts/beta-docker-version.sh
-      - name: Meilisearch (${{ env.MEILISEARCH_IMAGE }}) setup with Docker
-        run: docker run -d -p 7700:7700 getmeili/meilisearch:${{ env.MEILISEARCH_IMAGE }} meilisearch --master-key=masterKey --no-analytics
+      - name: Meilisearch (${{ needs.grep-docker-version.outputs.docker-version }}) setup with Docker
+        run: docker run -d -p 7700:7700 getmeili/meilisearch:${{ needs.grep-docker-version.outputs.docker-version }} meilisearch --master-key=masterKey --no-analytics
       - name: Install dependencies
         run: yarn --dev && yarn --cwd ./tests/env/react
       - name: Setup Meilisearch Index
@@ -55,6 +64,7 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
+    needs: ['grep-docker-version']
     strategy:
       fail-fast: false
       matrix:
@@ -72,12 +82,8 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '14.x'
-      - name: Grep beta version of Meilisearch
-        run: echo "MEILISEARCH_IMAGE=$(sh .github/scripts/beta-docker-version.sh)" >> $GITHUB_ENV
-      - name: Try version script
-        run: sh .github/scripts/beta-docker-version.sh
-      - name: Meilisearch (${{ env.MEILISEARCH_IMAGE }}) setup with Docker
-        run: docker run -d -p 7700:7700 getmeili/meilisearch:${{ env.MEILISEARCH_IMAGE }} meilisearch --master-key=masterKey --no-analytics
+      - name: Meilisearch (${{ needs.grep-docker-version.outputs.docker-version }}) setup with Docker
+        run: docker run -d -p 7700:7700 getmeili/meilisearch:${{ needs.grep-docker-version.outputs.docker-version }} meilisearch --master-key=masterKey --no-analytics
       - name: Install dependencies
         run: yarn install
       - name: Run tests


### PR DESCRIPTION
To communicate custom information to different jobs github recommends using the `needs` context. 
[See documentation](https://docs.github.com/en/actions/learn-github-actions/contexts#example-usage-of-the-needs-context)

In this CI, we are using cypress which does not have access to the repository files. Since we need access to it to be able to fetch the version of the docker image, we use this method as suggested by them [See doc](https://github.com/cypress-io/github-action#robust-custom-build-id).
