### PR TITLE
Update nodeJs requirements in readme and CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 16
           registry-url: https://registry.npmjs.org/
       - name: Check release validity
         run: sh .github/scripts/check-release.sh

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ This package only guarantees the compatibility with the [version v0.28.0 of Meil
 
 **Node / NPM versions**:
 
-- NodeJS >= 12.10 <= 14
+- NodeJS >= 12.10 <= 18
 - NPM >= 6.x
 
 ## 📜 API resources


### PR DESCRIPTION
Fixes the node js compatibility in readme
and make publishing use node 16