### PR TITLE
Feature prototype: define strategy on optional words

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ const searchClient = instantMeiliSearch(
 - [`finitePagination`](#finite-pagination): Used to work with the [`pagination`](#-pagination) widget (default: `false`) .
 - [`primaryKey`](#primary-key): Specify the primary key of your documents (default `undefined`).
 - [`keepZeroFacets`](#keep-zero-facets): Show the facets value even when they have 0 matches (default `false`).
+- [`optionalWords`](#optional-words): Determine the search strategy on words matching (default `last`). [See extented explaination](https://github.com/meilisearch/meilisearch/discussions/2639).
 
 The options are added as the third parameter of the `instantMeilisearch` function.
 
@@ -168,6 +169,19 @@ genres:
 
 ```js
 { keepZeroFacets : true } // default: false
+```
+
+### Optional words
+
+`optionalWords` gives you the possibility to chose how Meilisearch should handle the presence of multiple query words.
+
+For example, if your query is `Hello world` by default Meilisearch returns documents containing either both `Hello` and `world` or documents that only contain `hello`. This is the `last` strategy, where words are stripped from the right.
+The other strategy is `none`, where both `hello` and `worlds` **must** be present in a document for it to be returned.
+
+```js
+{
+  optionalWords: 'none' // default last
+}
 ```
 
 ## 🪡 Example with InstantSearch

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meilisearch/instant-meilisearch",
-  "version": "0.8.1",
+  "version": "0.8.1-optional-words-beta.0",
   "private": false,
   "description": "The search client to use Meilisearch with InstantSearch.",
   "scripts": {
@@ -57,7 +57,7 @@
     "url": "https://github.com/meilisearch/instant-meilisearch.git"
   },
   "dependencies": {
-    "meilisearch": "^0.27.0"
+    "meilisearch": "0.27.0-optional-words-beta.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.18.9",

--- a/src/adapter/search-request-adapter/search-params-adapter.ts
+++ b/src/adapter/search-request-adapter/search-params-adapter.ts
@@ -32,6 +32,7 @@ function MeiliParamsCreator(searchContext: SearchContext) {
     finitePagination,
     sort,
     pagination,
+    optionalWords,
   } = searchContext
 
   return {
@@ -119,6 +120,11 @@ function MeiliParamsCreator(searchContext: SearchContext) {
         }
       }
     },
+    addOptionalWords() {
+      if (optionalWords) {
+        meiliSearchParams.optionalWords = optionalWords
+      }
+    },
   }
 }
 
@@ -144,6 +150,7 @@ export function adaptSearchParams(
   meilisearchParams.addFilters()
   meilisearchParams.addSort()
   meilisearchParams.addGeoSearchRules()
+  meilisearchParams.addOptionalWords()
 
   return meilisearchParams.getParams()
 }

--- a/src/contexts/search-context.ts
+++ b/src/contexts/search-context.ts
@@ -37,6 +37,7 @@ export function createSearchContext(
     placeholderSearch: options.placeholderSearch !== false, // true by default
     keepZeroFacets: !!options.keepZeroFacets, // false by default
     finitePagination: !!options.finitePagination, // false by default
+    optionalWords: options.optionalWords || 'last',
   }
   return searchContext
 }

--- a/src/package-version.ts
+++ b/src/package-version.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '0.8.1'
+export const PACKAGE_VERSION = '0.8.1-optional-words-beta.0'

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -81,7 +81,7 @@ export type SearchContext = Omit<
     finitePagination: boolean
     sort?: string
     indexUid: string
-    placeholderSearch: boolean
+    placeholderSearch?: boolean
     primaryKey?: string
     optionalWords?: string
   }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -34,6 +34,7 @@ export type InstantMeiliSearchOptions = {
   keepZeroFacets?: boolean
   finitePagination?: boolean
   clientAgents?: string[]
+  optionalWords?: string
 }
 
 export type SearchCacheInterface = {
@@ -44,15 +45,6 @@ export type SearchCacheInterface = {
 }
 
 export type InsideBoundingBox = string | ReadonlyArray<readonly number[]>
-
-type ClientParams = {
-  primaryKey?: string
-  placeholderSearch?: boolean
-  sort?: string
-  indexUid: string
-  paginationTotalHits: number
-  finitePagination: boolean
-}
 
 export type GeoSearchContext = {
   aroundLatLng?: string
@@ -77,15 +69,22 @@ export type PaginationParams = {
 }
 
 export type SearchContext = Omit<
-  InstantSearchParams & ClientParams,
-  'insideBoundingBox' | 'paginationTotalHits'
-> & {
-  insideBoundingBox?: InsideBoundingBox
-  keepZeroFacets?: boolean
-  cropMarker?: string
-  defaultFacetDistribution: FacetDistribution
-  pagination: PaginationContext
-}
+  InstantSearchParams,
+  'insideBoundingBox' | 'optionalWords'
+> &
+  InstantSearchParams & {
+    insideBoundingBox?: InsideBoundingBox
+    keepZeroFacets?: boolean
+    cropMarker?: string
+    defaultFacetDistribution: FacetDistribution
+    pagination: PaginationContext
+    finitePagination: boolean
+    sort?: string
+    indexUid: string
+    placeholderSearch: boolean
+    primaryKey?: string
+    optionalWords?: string
+  }
 
 export type InstantMeiliSearchInstance = SearchClient & {
   clearCache: () => void

--- a/yarn.lock
+++ b/yarn.lock
@@ -5169,10 +5169,10 @@ mdn-data@2.0.4:
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.4.tgz#699b3c38ac6f1d728091a64650b65d388502fd5b"
   integrity sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==
 
-meilisearch@^0.27.0:
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/meilisearch/-/meilisearch-0.27.0.tgz#8bd57ddb77b975f93e054cb977b951c488ece297"
-  integrity sha512-kZOZFIuSO7c6xRf+Y2/9/h6A9pl0sCl/G44X4KuaSwxGbruOZPhmxbeVEgLHBv4pUFvQ56rNVTA/2d/5GCU1YA==
+meilisearch@0.27.0-optional-words-beta.0:
+  version "0.27.0-optional-words-beta.0"
+  resolved "https://registry.yarnpkg.com/meilisearch/-/meilisearch-0.27.0-optional-words-beta.0.tgz#ddfd83fcfa1cc27edda542e677e445c077233938"
+  integrity sha512-Wg93vbYEj7OlKL4IQmyAeRW2wcZo7SR5kXDoZBe6wBjaJ641iPDhgngVofjjGhAHHsZEOCM+84ebZ8iAUq1CcA==
   dependencies:
     cross-fetch "^3.1.5"
 


### PR DESCRIPTION
Introduces `optionalWords` search parameter.
It lets you decide the search strategy for words matching during a search.

See https://github.com/meilisearch/meilisearch/pull/2636


`optionalWords` gives you the possibility to chose how Meilisearch should handle the presence of multiple query words.

For example, if your query is `Hello world` by default Meilisearch returns documents containing either both `Hello` and `world` or documents that only contain `hello`. This is the `last` strategy, where words are stripped from the right.
The other strategy is `none`, where both `hello` and `worlds` **must** be present in a document for it to be returned.

```js
import { instantMeiliSearch } from '@meilisearch/instant-meilisearch'

const searchClient = instantMeiliSearch(
  host,
  apiKey,
  {
      optionalWords: 'none' // default last
  }
)
```
