### PR TITLE
Remove unecessary clientParams type

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -45,15 +45,6 @@ export type SearchCacheInterface = {
 
 export type InsideBoundingBox = string | ReadonlyArray<readonly number[]>
 
-type ClientParams = {
-  primaryKey?: string
-  placeholderSearch?: boolean
-  sort?: string
-  indexUid: string
-  paginationTotalHits: number
-  finitePagination: boolean
-}
-
 export type GeoSearchContext = {
   aroundLatLng?: string
   aroundLatLngViaIP?: boolean
@@ -76,16 +67,19 @@ export type PaginationParams = {
   page?: number
 }
 
-export type SearchContext = Omit<
-  InstantSearchParams & ClientParams,
-  'insideBoundingBox' | 'paginationTotalHits'
-> & {
-  insideBoundingBox?: InsideBoundingBox
-  keepZeroFacets?: boolean
-  cropMarker?: string
-  defaultFacetDistribution: FacetDistribution
-  pagination: PaginationContext
-}
+export type SearchContext = Omit<InstantSearchParams, 'insideBoundingBox'> &
+  InstantSearchParams & {
+    insideBoundingBox?: InsideBoundingBox
+    keepZeroFacets?: boolean
+    cropMarker?: string
+    defaultFacetDistribution: FacetDistribution
+    pagination: PaginationContext
+    finitePagination: boolean
+    sort?: string
+    indexUid: string
+    placeholderSearch?: boolean
+    primaryKey?: string
+  }
 
 export type InstantMeiliSearchInstance = SearchClient & {
   clearCache: () => void

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -69,14 +69,14 @@ export type PaginationParams = {
 
 export type SearchContext = Omit<InstantSearchParams, 'insideBoundingBox'> &
   InstantSearchParams & {
-    insideBoundingBox?: InsideBoundingBox
-    keepZeroFacets?: boolean
-    cropMarker?: string
     defaultFacetDistribution: FacetDistribution
     pagination: PaginationContext
     finitePagination: boolean
-    sort?: string
     indexUid: string
+    insideBoundingBox?: InsideBoundingBox
+    keepZeroFacets?: boolean
+    cropMarker?: string
+    sort?: string
     placeholderSearch?: boolean
     primaryKey?: string
   }


### PR DESCRIPTION
the type `ClientParams` was used nowhere and added a useless complexity to the types.

`paginationTotalHits` is not added in the `SearchContext` as it is added in, and used from the `PaginationContext` 

Types are also re-ordered in order to get the mandatory fields at the top and the optional after them