### PR TITLE
Change order of branches conditions in beta CI

### DIFF
--- a/.github/workflows/beta-tests.yml
+++ b/.github/workflows/beta-tests.yml
@@ -4,9 +4,9 @@ name: Beta tests
 # Will only run for PRs and pushes to *-beta
 on:
   push:
-    branches: ['!bump-meilisearch-v*.*.*-beta', '**-beta']
+    branches: ['**-beta', '!bump-meilisearch-v[0-9]*.[0-9]*.[0-9]*-beta']
   pull_request:
-    branches: ['!bump-meilisearch-v*.*.*-beta', '**-beta']
+    branches: ['**-beta', '!bump-meilisearch-v[0-9]*.[0-9]*.[0-9]*-beta']
 
 jobs:
   meilisearch-version:


### PR DESCRIPTION
The order made that the second condition was overriding the first one. Making the tests run anyway on bump beta;s