### PR TITLE
Update version for the next release (v0.8.2-beta.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meilisearch/instant-meilisearch",
-  "version": "0.8.1",
+  "version": "0.8.2-beta.0",
   "private": false,
   "description": "The search client to use Meilisearch with InstantSearch.",
   "scripts": {

--- a/src/package-version.ts
+++ b/src/package-version.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '0.8.1'
+export const PACKAGE_VERSION = '0.8.2-beta.0'


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v0.29.1 :tada:
Check out the changelog of [Meilisearch v0.29.1](https://github.com/meilisearch/meilisearch/releases/tag/v0.29.0rc1) for more information on the changes.

## 🚀 Enhancements

- New MeiliSearch option `matchingStrategy` #832
