### PR TITLE
Update version for the next release (v0.9.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meilisearch/instant-meilisearch",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "private": false,
   "description": "The search client to use Meilisearch with InstantSearch.",
   "scripts": {

--- a/src/package-version.ts
+++ b/src/package-version.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '0.8.2'
+export const PACKAGE_VERSION = '0.9.0'


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v0.29.0 :tada:
Check out the changelog of [Meilisearch v0.29.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.29.0) for more information on the changes.

## 🚀 Enhancements

- New Meilisearch option `matchingStrategy` #832

## ⚠️ Breaking Changes

This breaking change *__may not affect you__*, but in any case, you should check your search queries if you want to keep the same behavior from `v0.28`.

- The `NOT` filter keyword does not have an implicitly `EXIST` operator anymore. Check out for more information: https://github.com/meilisearch/meilisearch/issues/2486