### PR TITLE
fix: readme sortBy widget example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1054,7 +1054,7 @@ See [relevancy guide](https://docs.meilisearch.com/learn/core_concepts/relevancy
     items: [
       { value: 'clothes', label: 'Relevant' }, // default index
       {
-        value: 'clothes:price:asc', // Sort on descending price
+        value: 'clothes:price:desc', // Sort on descending price
         label: 'Ascending price using query time sort',
       },
       {


### PR DESCRIPTION
https://docs.meilisearch.com/reference/api/settings.html#update-ranking-rules documents that `desc` is the keyword for descending order

# Pull Request

## Related issue


## What does this PR do?
- Update readme example of descending sortBy widget

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
