### PR TITLE
Update version for the next release (v0.10.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meilisearch/instant-meilisearch",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": false,
   "description": "The search client to use Meilisearch with InstantSearch.",
   "scripts": {

--- a/src/package-version.ts
+++ b/src/package-version.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '0.9.0'
+export const PACKAGE_VERSION = '0.10.0'


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v0.30.0 :tada:
Check out the changelog of [Meilisearch v0.30.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.30.0) for more information on the changes.

## ⚠️ Breaking change

- `paginationTotalHits` does not exist anymore #878 

## 🚀 Enchancement

- `finitePagination` is now showcasing the exact number of pages based on the total number of document matched. #878 