### PR TITLE
Keep both _geo and _geoloc fields in hits and hits._formatted

### DIFF
--- a/src/adapter/search-response-adapter/__tests__/geo-adapter.tests.ts
+++ b/src/adapter/search-response-adapter/__tests__/geo-adapter.tests.ts
@@ -1,0 +1,52 @@
+import { adaptGeoResponse } from '../geo-reponse-adapter'
+
+describe('Geopoint adapter', () => {
+  test('_geoloc field should be created in hit object with _geo fields', () => {
+    const hits = [
+      {
+        id: 2,
+        _geo: {
+          lat: 1,
+          lng: 2,
+        },
+        _formatted: {
+          _geo: {
+            lat: 1,
+            lng: 2,
+          },
+        },
+      },
+    ]
+
+    const adaptedHits = adaptGeoResponse(hits)
+
+    expect(adaptedHits[0]._geoloc).toEqual(hits[0]._geo)
+    expect(adaptedHits[0]._geo).toEqual(hits[0]._geo)
+    expect(adaptedHits[0]._formatted._geoloc).toEqual(hits[0]._formatted._geo)
+    expect(adaptedHits[0]._formatted._geo).toEqual(hits[0]._formatted._geo)
+    expect(adaptedHits[0].objectID).toBeDefined()
+    expect(adaptedHits[0]._formatted.objectID).toEqual(adaptedHits[0].objectID)
+  })
+
+  test('_geoloc field should not be created in hit object without _geo fields', () => {
+    const hits = [
+      {
+        id: 2,
+      },
+      {
+        id: 1,
+        _formatted: {},
+      },
+    ]
+
+    const adaptedHits = adaptGeoResponse(hits)
+
+    expect(adaptedHits[0]._geoloc).toBeUndefined()
+    expect(adaptedHits[0]._geo).toBeUndefined()
+    expect(adaptedHits[0]._formatted).toBeUndefined()
+    expect(adaptedHits[1]._geoloc).toBeUndefined()
+    expect(adaptedHits[1]._geo).toBeUndefined()
+    expect(adaptedHits[1]._formatted._geoloc).toBeUndefined()
+    expect(adaptedHits[1]._formatted._geo).toBeUndefined()
+  })
+})

--- a/src/adapter/search-response-adapter/geo-reponse-adapter.ts
+++ b/src/adapter/search-response-adapter/geo-reponse-adapter.ts
@@ -4,14 +4,15 @@
  */
 export function adaptGeoResponse(hits: any[]): Array<Record<string, any>> {
   for (let i = 0; i < hits.length; i++) {
+    const objectID = `${i + Math.random() * 1000000}`
     if (hits[i]._geo) {
-      hits[i]._geoloc = {
-        lat: hits[i]._geo.lat,
-        lng: hits[i]._geo.lng,
-      }
+      hits[i]._geoloc = hits[i]._geo
+      hits[i].objectID = objectID
+    }
 
-      hits[i].objectID = `${i + Math.random() * 1000000}`
-      delete hits[i]._geo
+    if (hits[i]._formatted?._geo) {
+      hits[i]._formatted._geoloc = hits[i]._formatted._geo
+      hits[i]._formatted.objectID = objectID
     }
   }
   return hits


### PR DESCRIPTION
Instantsearch geo widget requires the geo field to be named `_geoloc`. Nonetheless, the field returned from meilisearch is `_geo`. 

Previously we replaced `_geo` with `_geoloc` at the root of the hits (so not in `_formatted`) which in itself was a bug.

Since `instantsearch` needs `_geoloc` but we also want to avoid confusing the user to why their `_geo` field disappeared, we decided to keep both `_geo` and `_geoloc` files at the root of the hit but also in _formatted (of course only if there was a `_geo` field present to begin with).

