### PR TITLE
Add beta release process

### DIFF
--- a/.github/scripts/beta-docker-version.sh
+++ b/.github/scripts/beta-docker-version.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-package_json_version=$(grep '"version":' package.json | cut -d ':' -f 2- | tr -d ' ' | tr -d '"' | tr -d ',')
-beta_feature=$(echo $package_json_version | sed -r 's/[0-9]+.[0-9]+.[0-9]+-//')
-beta_feature=$(echo $beta_feature | sed -r 's/-beta\.[0-9]*$//')
-
-docker_image=$(curl https://hub.docker.com/v2/repositories/getmeili/meilisearch/tags | jq | grep "$beta_feature" | head -1)
-docker_image=$(echo $docker_image | grep '"name":' | cut -d ':' -f 2- | tr -d ' ' | tr -d '"' | tr -d ',')
-echo $docker_image

--- a/.github/scripts/check-tag-format.sh
+++ b/.github/scripts/check-tag-format.sh
@@ -5,11 +5,11 @@ is_pre_release=$1
 current_tag=$(echo $GITHUB_REF | cut -d '/' -f 3 | tr -d ' ',v)
 
 if [ $is_pre_release = false ]; then
-  # Works with the format vX.X.X
+  # Works with the format vX.X.X, X being numbers
   #
   # Example of correct format:
   # v0.1.0
-  echo "$current_tag" | grep -E "[0-9]*\.[0-9]*\.[0-9]*$"
+  echo "$current_tag" | grep -E "^[0-9]+\.[0-9]+\.[0-9]+$"
   if [ $? != 0 ]; then
     echo "Error: Your tag: $current_tag is wrongly formatted."
     echo 'Please refer to the contributing guide for help.'
@@ -17,14 +17,12 @@ if [ $is_pre_release = false ]; then
   fi
   exit 0
 elif [ $is_pre_release = true ]; then
-  # Works with the format vX.X.X-xxx-beta.X
-  # none or multiple -xxx are valid
+  # Works with the format vX.X.X-**.X, X being numbers
   #
   # Examples of correct format:
-  # v0.1.0-beta.0
-  # v0.1.0-xxx-beta.0
-  # v0.1.0-xxx-xxx-beta.0
-  echo "$current_tag" | grep -E "[0-9]*\.[0-9]*\.[0-9]*-([a-z]*-)*beta\.[0-9]*$"
+  # 0.2.0-pagination.1
+  # 0.2.0-v0.30.0-pre-release.0
+  echo "$current_tag" | grep -E "^[0-9]+\.[0-9]+\.[0-9]+-.*\.[0-9]*$"
 
   if [ $? != 0 ]; then
     echo "Error: Your beta tag: $current_tag is wrongly formatted."

--- a/.github/scripts/prototype-docker-version.sh
+++ b/.github/scripts/prototype-docker-version.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# See https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables for references on GITHUB_REF_NAME
+prototype_branch=$1                                                        # $GITHUB_REF_NAME
+prototype_branch=$(echo $prototype_branch | sed -r 's/prototype-beta\///') # remove pre-prending prototype-beta/
+prototype_name=$(echo $prototype_branch | sed -r 's/-beta//')              # remove appended -beta
+
+docker_image=$(curl "https://hub.docker.com/v2/repositories/getmeili/meilisearch/tags?&page_size=100" | jq | grep "$prototype_name" | head -1)
+docker_image=$(echo $docker_image | grep '"name":' | cut -d ':' -f 2- | tr -d ' ' | tr -d '"' | tr -d ',')
+echo $docker_image

--- a/.github/workflows/meilisearch-prototype-tests.yml
+++ b/.github/workflows/meilisearch-prototype-tests.yml
@@ -1,26 +1,34 @@
 # Testing the code base against a specific Meilisearch feature
-name: Beta tests
+name: Meilisearch prototype tests
 
 # Will only run for PRs and pushes to *-beta
 on:
-  push:
-    branches: ['**-beta', '!bump-meilisearch-v[0-9]*.[0-9]*.[0-9]*-beta']
   pull_request:
-    branches: ['**-beta', '!bump-meilisearch-v[0-9]*.[0-9]*.[0-9]*-beta']
+    branches:
+      - 'prototype-beta/**'
+  push:
+    branches:
+      - 'prototype-beta/**'
 
 jobs:
   meilisearch-version:
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.grep-step.outputs.version }}
+      version: ${{ steps.grep-step.outputs.meilisearch_version }}
     steps:
       - uses: actions/checkout@v3
       - name: Grep docker beta version of Meilisearch
         id: grep-step
         run: |
-          MEILISEARCH_VERSION=$(sh .github/scripts/beta-docker-version.sh)
-          echo $MEILISEARCH_VERSION
-          echo ::set-output name=version::$MEILISEARCH_VERSION
+          MEILISEARCH_VERSION=$(sh .github/scripts/prototype-docker-version.sh $GITHUB_REF_NAME)
+          if [ -z "$MEILISEARCH_VERSION" ]
+          then
+            echo "Could not find any docker image for this prototype"
+            exit 1
+          else
+            echo $MEILISEARCH_VERSION
+          fi
+          echo "meilisearch_version=$MEILISEARCH_VERSION" >> $GITHUB_OUTPUT
   cypress-run:
     runs-on: ubuntu-latest
     needs: ['meilisearch-version']
@@ -46,7 +54,7 @@ jobs:
       - name: Setup Meilisearch Index
         run: yarn local:env:setup
       - name: Run local browser tests
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v3
         with:
           wait-on: 'http://localhost:7700'
           # Tests are only done on one playground to avoid long testing time

--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -3,26 +3,31 @@ name: Pre-Release Tests
 
 # Will only run for PRs and pushes to bump-meilisearch-v*
 on:
-  push:
-    branches: [bump-meilisearch-v*]
   pull_request:
-    branches: [bump-meilisearch-v*]
+    branches:
+      - 'bump-meilisearch-v**'
+      - 'pre-release-beta/**'
+  push:
+    branches:
+      - 'bump-meilisearch-v**'
+      - 'pre-release-beta/**'
 
 jobs:
   meilisearch-version:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || !startsWith(github.base_ref, 'bump-meilisearch-v')
     outputs:
-      version: ${{ steps.grep-step.outputs.version }}
+      version: ${{ steps.grep-step.outputs.meilisearch_version }}
     steps:
       - uses: actions/checkout@v3
       - name: Grep docker beta version of Meilisearch
         id: grep-step
         run: |
           MEILISEARCH_VERSION=$(curl https://raw.githubusercontent.com/meilisearch/integration-guides/main/scripts/get-latest-meilisearch-rc.sh | sh)
-          echo $MEILISEARCH_VERSION
-          echo ::set-output name=version::$MEILISEARCH_VERSION
+          echo "meilisearch_version=$MEILISEARCH_VERSION" >> $GITHUB_OUTPUT
   cypress-run:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || !startsWith(github.base_ref, 'bump-meilisearch-v')
     needs: ['meilisearch-version']
     services:
       meilisearch:
@@ -46,7 +51,7 @@ jobs:
       - name: Setup Meilisearch Index
         run: yarn local:env:setup
       - name: Run local browser tests
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v2
         with:
           wait-on: 'http://localhost:7700'
           # Tests are only done on one playground to avoid long testing time
@@ -62,9 +67,9 @@ jobs:
         with:
           name: cypress-videos
           path: cypress/videos
-
   integration_tests:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || !startsWith(github.base_ref, 'bump-meilisearch-v')
     needs: ['meilisearch-version']
     services:
       meilisearch:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,12 +21,12 @@ jobs:
       - name: Build instant-meilisearch
         run: yarn build
       - name: Publish with latest tag
-        if: "!github.event.release.prerelease && !contains(github.ref, 'beta')"
+        if: '!github.event.release.prerelease'
         run: npm publish .
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Publish with beta tag
-        if: "github.event.release.prerelease && contains(github.ref, 'beta')"
+        if: 'github.event.release.prerelease'
         run: npm publish . --tag beta
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,16 @@ jobs:
   cypress-run:
     runs-on: ubuntu-latest
     # Will not run if the event is a PR to bump-meilisearch-v* (so a pre-release PR)
-    # Will still run for each push to bump-meilisearch-v*
-    if: github.event_name != 'pull_request' || !startsWith(github.base_ref, 'bump-meilisearch-v')
+    # Will not run if the event is a PR to pre-release-beta/*
+    # Will not run if the event is a PR to prototype-beta/*
+    # Will not run if the event is a push on pre-release-beta/*
+    # Will still run for each push to bump-meilisearch-v* and prototype-beta/*
+    if: |
+      github.event_name != 'pull_request' ||
+      !startsWith(github.base_ref, 'bump-meilisearch-v') &&
+      !startsWith(github.base_ref, 'pre-release-beta/') &&
+      !startsWith(github.base_ref, 'prototype-beta/') &&
+      !startsWith(github.head_ref, 'pre-release-beta/')
     services:
       meilisearch:
         image: getmeili/meilisearch:latest
@@ -37,7 +45,7 @@ jobs:
       - name: Setup Meilisearch Index
         run: yarn local:env:setup
       - name: Run local browser tests
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v3
         with:
           wait-on: 'http://localhost:7700'
           # Tests are only done on one playground to avoid long testing time
@@ -55,8 +63,16 @@ jobs:
           path: cypress/videos
   integration_tests:
     # Will not run if the event is a PR to bump-meilisearch-v* (so a pre-release PR)
-    # Will still run for each push to bump-meilisearch-v*
-    if: github.event_name != 'pull_request' || !startsWith(github.base_ref, 'bump-meilisearch-v')
+    # Will not run if the event is a PR to pre-release-beta/*
+    # Will not run if the event is a PR to prototype-beta/*
+    # Will not run if the event is a push on pre-release-beta/*
+    # Will still run for each push to bump-meilisearch-v* and prototype-beta/*
+    if: |
+      github.event_name != 'pull_request' ||
+      !startsWith(github.base_ref, 'bump-meilisearch-v') &&
+      !startsWith(github.base_ref, 'pre-release-beta/') &&
+      !startsWith(github.base_ref, 'prototype-beta/') &&
+      !startsWith(github.head_ref, 'pre-release-beta/')
     runs-on: ubuntu-latest
     services:
       meilisearch:
@@ -85,13 +101,12 @@ jobs:
       - name: Build project
         run: yarn build
   style_tests:
-    # Will not run if the event is a PR to bump-meilisearch-v* (so a pre-release PR)
-    # Will still run for each push to bump-meilisearch-v*
-    if: github.event_name != 'pull_request' || !startsWith(github.base_ref, 'bump-meilisearch-v')
     name: style-check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: head ref
+        run: echo $GITHUB_HEAD_REF
       - name: Setup node
         uses: actions/setup-node@v3
         with:
@@ -106,9 +121,6 @@ jobs:
         with:
           config_file: .yamllint.yml
   types_tests:
-    # Will not run if the event is a PR to bump-meilisearch-v* (so a pre-release PR)
-    # Will still run for each push to bump-meilisearch-v*
-    if: github.event_name != 'pull_request' || !startsWith(github.base_ref, 'bump-meilisearch-v')
     runs-on: ubuntu-latest
     name: types-check
     steps:


### PR DESCRIPTION
This repository is able to create mutiple types of beta:

- A normal beta for the package. Example, I add a feature in instant-meilisearch and would like to publish a beta on npm to try it out.
- A beta implementing the changes of a future release of Meilisearch. [Example](https://github.com/meilisearch/instant-meilisearch/pull/881)
- A beta of a specific prototype of Meilisearch. [Example](https://github.com/meilisearch/instant-meilisearch/pull/817)

Each of these beta must run against a specific type of tests.
- the normal beta has to run against the latest release of Meilisearch
- the pre-release beta against the latest rc of Meilisearch
- the prototype beta against the meilisearch docker image of the prototype

This PR introduces the new process to make this as simple as possible. To be able to redirect the PR's to the correct tests a new formating is suggested on the branch name. For consistency, a new formating is suggested on the package version.

The `check-tag-version` script ensures that if the version is not a `vX.X.X` it should be a pre-release.
the `prototype-docker-version` parse the branch name to fetch the correct image on the docker API.


