### PR TITLE
Multi-index search: fix placeholdersearch not working properly with filters and pagination

### DIFF
--- a/src/adapter/search-request-adapter/__tests__/search-params.tests.ts
+++ b/src/adapter/search-request-adapter/__tests__/search-params.tests.ts
@@ -5,6 +5,8 @@ const DEFAULT_CONTEXT = {
   indexUid: 'test',
   pagination: { page: 0, hitsPerPage: 6, finite: false },
   defaultFacetDistribution: {},
+  placeholderSearch: true,
+  keepZeroFacets: false,
 }
 
 describe('Parameters adapter', () => {
@@ -155,6 +157,31 @@ describe('Pagination adapter', () => {
     expect(searchParams.hitsPerPage).toBe(0)
   })
 
+  test('adapting a finite pagination with no placeholderSearch and a query', () => {
+    const searchParams = adaptSearchParams({
+      ...DEFAULT_CONTEXT,
+      query: 'a',
+      pagination: { page: 4, hitsPerPage: 6, finite: true },
+      placeholderSearch: false,
+    })
+
+    expect(searchParams.page).toBe(5)
+    expect(searchParams.hitsPerPage).toBeGreaterThan(0)
+  })
+
+  test('adapting a finite pagination with no placeholderSearch and a facetFilter', () => {
+    const searchParams = adaptSearchParams({
+      ...DEFAULT_CONTEXT,
+      query: '',
+      pagination: { page: 4, hitsPerPage: 6, finite: true },
+      placeholderSearch: false,
+      facetFilters: ['genres:Action'],
+    })
+
+    expect(searchParams.page).toBe(5)
+    expect(searchParams.hitsPerPage).toBeGreaterThan(0)
+  })
+
   test('adapting a scroll pagination with no placeholderSearch', () => {
     const searchParams = adaptSearchParams({
       ...DEFAULT_CONTEXT,
@@ -165,5 +192,30 @@ describe('Pagination adapter', () => {
 
     expect(searchParams.limit).toBe(0)
     expect(searchParams.offset).toBe(0)
+  })
+
+  test('adapting a scroll pagination with no placeholderSearch and a query', () => {
+    const searchParams = adaptSearchParams({
+      ...DEFAULT_CONTEXT,
+      query: 'a',
+      pagination: { page: 4, hitsPerPage: 6, finite: false },
+      placeholderSearch: false,
+    })
+
+    expect(searchParams.limit).toBeGreaterThan(0)
+    expect(searchParams.offset).toBeGreaterThan(0)
+  })
+
+  test('adapting a scroll pagination with no placeholderSearch and a facetFilter', () => {
+    const searchParams = adaptSearchParams({
+      ...DEFAULT_CONTEXT,
+      query: 'a',
+      pagination: { page: 4, hitsPerPage: 6, finite: false },
+      placeholderSearch: false,
+      facetFilters: ['genres:Action'],
+    })
+
+    expect(searchParams.limit).toBeGreaterThan(0)
+    expect(searchParams.offset).toBeGreaterThan(0)
   })
 })

--- a/src/adapter/search-request-adapter/search-resolver.ts
+++ b/src/adapter/search-request-adapter/search-resolver.ts
@@ -25,8 +25,6 @@ export function SearchResolver(
       searchContext: SearchContext,
       searchParams: MeiliSearchParams
     ): Promise<MeiliSearchResponse<Record<string, any>>> {
-      const { placeholderSearch, query } = searchContext
-
       // Create cache key containing a unique set of search parameters
       const key = cache.formatKey([
         searchParams,
@@ -54,13 +52,9 @@ export function SearchResolver(
         )
       }
 
-      // query can be: empty string, undefined or null
-      // all of them are falsy's
-      if (!placeholderSearch && !query) {
-        searchResponse.hits = []
-      }
       // Cache response
       cache.setEntry<MeiliSearchResponse>(key, searchResponse)
+
       return searchResponse
     },
   }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -78,11 +78,11 @@ export type SearchContext = Omit<InstantSearchParams, 'insideBoundingBox'> &
     defaultFacetDistribution: FacetDistribution
     pagination: PaginationState
     indexUid: string
+    placeholderSearch: boolean
+    keepZeroFacets: boolean
     insideBoundingBox?: InsideBoundingBox
-    keepZeroFacets?: boolean
     cropMarker?: string
     sort?: string
-    placeholderSearch?: boolean
     primaryKey?: string
     matchingStrategy?: MatchingStrategies
   }

--- a/tests/placeholder-search.tests.ts
+++ b/tests/placeholder-search.tests.ts
@@ -51,4 +51,48 @@ describe('Pagination browser test', () => {
     const hits = response.results[0].hits
     expect(hits.length).toBe(0)
   })
+
+  test('placeholdersearch with query', async () => {
+    const customClient = instantMeiliSearch(
+      'http://localhost:7700',
+      'masterKey',
+      {
+        placeholderSearch: false,
+      }
+    )
+
+    const response = await customClient.search<Movies>([
+      {
+        indexName: 'movies',
+        params: {
+          query: 'a',
+        },
+      },
+    ])
+
+    const hits = response.results[0].hits
+    expect(hits.length).toBeGreaterThan(0)
+  })
+
+  test('placeholdersearch set to false with filter', async () => {
+    const customClient = instantMeiliSearch(
+      'http://localhost:7700',
+      'masterKey',
+      {
+        placeholderSearch: false,
+      }
+    )
+
+    const response = await customClient.search<Movies>([
+      {
+        indexName: 'movies',
+        params: {
+          facetFilters: ['genres:Action'],
+        },
+      },
+    ])
+
+    const hits = response.results[0].hits
+    expect(hits.length).toBeGreaterThan(0)
+  })
 })


### PR DESCRIPTION
`placeholderSearch` lets you enable (default) or disable the rendering of the hits when an empty search is made.
An empty search is a search without any query and without any filters.

When `placeholderSearch` was set to false, hits did not render when a filter was required.
When `placeholderSearch` was set to false, the pagination was rendered of is placeholder search was set to true.

With this PR:

- When placeholderSearch is set to false, If you add a filter, by clicking on a facet for example, hits are rendered
- When placeholderSearch is set to false, when the query and the filters are empty, the pagination does not render any page. 
    - In finitePagination this is what is rendered:
        <img width="120" alt="Screenshot 2022-12-08 at 15 54 54" src="https://user-images.githubusercontent.com/33010418/206478647-a9922af9-2a24-4197-86d3-5b3377e99e0f.png">
   - in scroll pagination: the load more button is disabled
        <img width="113" alt="Screenshot 2022-12-08 at 15 55 51" src="https://user-images.githubusercontent.com/33010418/206478859-f142df89-fce6-4dc3-b358-a641c9be045e.png">


