### PR TITLE
Fix building fail in @meilisearch/vue-playground

### DIFF
--- a/playgrounds/vue3-ts/package.json
+++ b/playgrounds/vue3-ts/package.json
@@ -7,7 +7,8 @@
     "dev": "vite --open",
     "build": "vue-tsc && vite build",
     "preview": "vite preview",
-    "lint": "eslint --ext .ts,.vue,.js,.cjs ."
+    "lint": "eslint --ext .ts,.vue,.js,.cjs .",
+    "types": "yarn tsc"
   },
   "dependencies": {
     "@meilisearch/instant-meilisearch": "*",

--- a/playgrounds/vue3-ts/src/types/shims-vue.d.ts
+++ b/playgrounds/vue3-ts/src/types/shims-vue.d.ts
@@ -1,0 +1,8 @@
+declare module '*.vue' {
+  import { defineComponent } from 'vue'
+
+  const component: ReturnType<typeof defineComponent>
+  export default component
+}
+
+declare module 'vue-instantsearch/vue3/es'


### PR DESCRIPTION
the `vue` playground could not be build because of missing type files not related to instant-meilisearch. This PR adds a work-arround to ignore the issue.