### PR TITLE
Update the way we trigger tests in CI's

### DIFF
--- a/.github/workflows/meilisearch-prototype-tests.yml
+++ b/.github/workflows/meilisearch-prototype-tests.yml
@@ -50,15 +50,14 @@ jobs:
           node-version: 16
           cache: yarn
       - name: Install dependencies
-        run: yarn --dev && yarn --cwd ./tests/env/react
-      - name: Setup Meilisearch Index
-        run: yarn local:env:setup
+        run: yarn
       - name: Run local browser tests
         uses: cypress-io/github-action@v4
         with:
+          project: ./playgrounds/local-react
           wait-on: 'http://localhost:7700'
           # Tests are only done on one playground to avoid long testing time
-          start: yarn local:env:react
+          start: yarn playground:local-react
           env: playground=local
       - uses: actions/upload-artifact@v3
         if: failure()

--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -47,15 +47,14 @@ jobs:
           node-version: 16
           cache: yarn
       - name: Install dependencies
-        run: yarn --dev && yarn --cwd ./tests/env/react
-      - name: Setup Meilisearch Index
-        run: yarn local:env:setup
+        run: yarn
       - name: Run local browser tests
         uses: cypress-io/github-action@v4
         with:
+          project: ./playgrounds/local-react
           wait-on: 'http://localhost:7700'
           # Tests are only done on one playground to avoid long testing time
-          start: yarn local:env:react
+          start: yarn playground:local-react
           env: playground=local
       - uses: actions/upload-artifact@v3
         if: failure()


### PR DESCRIPTION
The way we trigger tests were changed, see #953. While they were updated in the `tests.yml` CI file, they also needed to be updated in the pre-release and beta CI's