### PR TITLE
Automerge dependencies with a patch updage from dependabot

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,16 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    branches:
+      - 'dependabot/**'
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: patch
+          github-token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
To avoid having to manually merge patches version updates opened by dependabot, this PR adds a github actions that automatically merges them.