### PR TITLE
Update version for the next release (v0.10.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meilisearch/instant-meilisearch",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": false,
   "description": "The search client to use Meilisearch with InstantSearch.",
   "scripts": {

--- a/src/package-version.ts
+++ b/src/package-version.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '0.10.1'
+export const PACKAGE_VERSION = '0.10.2'


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v1.0.0 :tada:
Check out the changelog of [Meilisearch v1.0.0](https://github.com/meilisearch/meilisearch/releases/tag/v1.0.0) for more information on the changes.