### PR TITLE
Remove beta release process in publish CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,19 +20,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - name: Install dependencies
         run: yarn
-      - name: Create Beta Release Pull Request or Publish to npm
-        if: contains(github.ref, 'beta')
-        uses: changesets/action@v1
-        with:
-          # https://github.com/changesets/changesets/blob/main/docs/prereleases.md
-          # https://github.com/changesets/changesets/blob/main/docs/command-line-options.md#publish
-          publish: yarn beta-release
-          version: yarn version-packages
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Create Release Pull Request or Publish to npm
-        if: contains(github.ref, 'beta') == false
         uses: changesets/action@v1
         with:
           publish: yarn release

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "instant-meilisearch:test:watch": "yarn --cwd ./packages/instant-meilisearch test:watch",
     "test:types": "turbo run test:types",
     "version-packages": "changeset version && turbo version",
-    "beta-release": "yarn build && changeset publish --tag beta",
     "release": "yarn build && changeset publish"
   },
   "private": true,


### PR DESCRIPTION
The initial idea was that every pre-release should be published under the dist tag `beta` tag in `npm` (see [tag tab in npm](https://www.npmjs.com/package/@meilisearch/instant-meilisearch?activeTab=versions)).

Unfortunately, it appears that when publishing a pre-release, `changesets` add a condition where we cannot add a custom tag. See issue https://github.com/changesets/changesets/issues/1037

Thus, the new way of doing it is to let changeset create a npm dist tag named after the pre-release version, in our case: `turbo-migration`. Once we consider this tag not to be relevant anymore, we can remove it from npm using [`npm-dist-tag`](https://docs.npmjs.com/cli/v9/commands/npm-dist-tag). 

Thus, every once in a while, a cleanup will be done to remove old tags that are not relevant anymore to avoid having to many dist tags listed in NPM.