### PR TITLE
Create required npmrc file upon publishing packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,13 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - name: Install dependencies
         run: yarn
+      - name: Creating .npmrc
+        run: |
+          cat << EOF > "$HOME/.npmrc"
+            //registry.npmjs.org/:_authToken=$NPM_TOKEN
+          EOF
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@v1
         with:


### PR DESCRIPTION
As per the doc of the changesets github action (see [here](https://github.com/changesets/action#with-publishing)


> By default the GitHub Action creates a .npmrc file with the following content:
>
> //registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}
> However, if a .npmrc file is found, the GitHub Action does not recreate the file. This is useful if you need to configure the .npmrc file on your own. For example, you can add a step before running the Changesets GitHub Action:

We need to add an additional step to create the `npmrc` at the root of the repo during the publish action.