### PR TITLE
Explicitely provide a NODE_AUTH_TOKEN in the publish CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,8 @@ on:
       - 'pre-release-beta/**'
       - 'beta/**'
       - 'prototype-beta/'
+env:
+  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
 jobs:
   publish-npm:
@@ -16,17 +18,23 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: '16.x'
           registry-url: https://registry.npmjs.org/
       - name: Install dependencies
         run: yarn
-      - name: Creating .npmrc
+      - name: Check if npmrc was created
+        run: ls -lah
+      - name: Show what's inside npmrc
+        run: cat .npmrc
+      - name: re create .npmrc file
         run: |
           cat << EOF > "$HOME/.npmrc"
             //registry.npmjs.org/:_authToken=$NPM_TOKEN
           EOF
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Show what's inside npmrc after re-creation of npmrc file
+        run: cat .npmrc
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@v1
         with:
@@ -35,3 +43,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
After having the CI fail again, one of the possibilities of fixing this issue is suggested by this user in this [comment](https://github.com/changesets/action/issues/98#issuecomment-917292485).

Another possibility is that `actions/setup-node@v3` also creates a npmrc that requires a `NPM_AUTH_TOKEN` see [doc](https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry)

This PR's commit is bound to be removed from #939 and is there for trying purposes.