### PR TITLE
Exit pre-release mode for next release

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "turbo-migration",
   "initialVersions": {
     "@meilisearch/instant-meilisearch": "0.10.1",


### PR DESCRIPTION
Since #939 has been released in pre-release mode and then pushed to main, we now need to exit pre-release mode.

As per [the documentation](https://github.com/changesets/changesets/blob/main/docs/prereleases.md)