### PR TITLE
Make umd build compatible in a node environment

### DIFF
--- a/.changeset/perfect-dodos-call.md
+++ b/.changeset/perfect-dodos-call.md
@@ -1,0 +1,5 @@
+---
+"@meilisearch/instant-meilisearch": minor
+---
+
+Makes the umd build work in a nodeJs environment

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "playground:vue3": "turbo run dev --filter=@meilisearch/vue3-ts-playground --parallel",
     "playground:react": "turbo run dev --filter=@meilisearch/react-playground --parallel",
     "playground:local-react": "turbo run dev --filter=@meilisearch/local-react-playground --parallel",
+    "playground:node": "turbo run dev --filter=@meilisearch/node-playground --parallel",
     "test:e2e": "turbo run test:e2e",
     "test:e2e:watch": "turbo run test:e2e:watch",
     "lint": "turbo lint",

--- a/packages/instant-meilisearch/rollup.config.js
+++ b/packages/instant-meilisearch/rollup.config.js
@@ -35,6 +35,7 @@ module.exports = [
   // browser-friendly IIFE build
   {
     input: INPUT, // directory to transpilation of typescript
+    external: ['cross-fetch', 'cross-fetch/polyfill'],
     output: {
       name: 'window',
       extend: true,

--- a/playgrounds/node-env/index.js
+++ b/playgrounds/node-env/index.js
@@ -1,0 +1,28 @@
+const { instantMeiliSearch } = require('@meilisearch/instant-meilisearch')
+const { MeiliSearch } = require('meilisearch')
+
+
+const client = instantMeiliSearch('http://localhost:7700', 'masterKey', {})
+const msClient = new MeiliSearch({ host: 'http://localhost:7700', apiKey: 'masterKey'})
+
+;(async() => {
+  try {
+    const task1 = await msClient.index('node_test').addDocuments([])
+    await msClient.waitForTask(task1.taskUid)
+    await client.search([
+      {
+        indexName: 'node_test',
+        params: {
+          query: '',
+        },
+      }
+    ])
+
+    const task2 = await msClient.index('node_test').delete()
+    await msClient.waitForTask(task2.taskUid)
+    process.exit(0)
+  } catch(e) {
+    console.error('Could not run the `umd` build in a node environment')
+    process.exit(1)
+  }
+})()

--- a/playgrounds/node-env/package.json
+++ b/playgrounds/node-env/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@meilisearch/node-playground",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Instant-meilisearch playground written in node",
+  "main": "index.js",
+  "scripts": {
+    "build": "node index.js"
+  },
+  "devDependencies": {
+    "eslint-config-meilisearch": "*"
+  },
+  "browserslist": [
+    "defaults"
+  ],
+  "license": "MIT",
+  "dependencies": {
+    "@meilisearch/instant-meilisearch": "*"
+  }
+}


### PR DESCRIPTION
the `umd` build of this package was missing the polyfill of `fetch`. Resulting in the following being thrown

```
XMLHttpRequest is not defined
```

As the package tries to use the browser `fetch` API.

Fixes: #1061 