### PR TITLE
Change the cmd to run the script in the node-playground

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,6 +99,8 @@ jobs:
         run: yarn test
       - name: Build all the playgrounds and the packages
         run: yarn build
+      - name: Run the node playground
+        run: yarn playground:node
   style_tests:
     name: style-check
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "playground:vue3": "turbo run dev --filter=@meilisearch/vue3-ts-playground --parallel",
     "playground:react": "turbo run dev --filter=@meilisearch/react-playground --parallel",
     "playground:local-react": "turbo run dev --filter=@meilisearch/local-react-playground --parallel",
-    "playground:node": "turbo build dev --filter=@meilisearch/node-playground --parallel",
+    "playground:node": "turbo run dev --filter=@meilisearch/node-playground --parallel",
     "test:e2e": "turbo run test:e2e",
     "test:e2e:watch": "turbo run test:e2e:watch",
     "lint": "turbo lint",

--- a/playgrounds/node-env/package.json
+++ b/playgrounds/node-env/package.json
@@ -5,7 +5,7 @@
   "description": "Instant-meilisearch playground written in node",
   "main": "index.js",
   "scripts": {
-    "build": "node index.js"
+    "dev": "node index.js"
   },
   "devDependencies": {
     "eslint-config-meilisearch": "*"


### PR DESCRIPTION
The build command in the node playground was run whenever the release was triggered. But in reality the node playground does not need to be built, it rather runs a script to see if it can interact correctly with instant meilisearch.

This PR changes the command from build to dev so that turbo build does not trigger it. It also adds a line in the test ci to ensure the script runs correctly