### PR TITLE
Fix multi words filters not formatted correctly

### DIFF
--- a/.changeset/tender-dancers-check.md
+++ b/.changeset/tender-dancers-check.md
@@ -1,0 +1,5 @@
+---
+"@meilisearch/instant-meilisearch": patch
+---
+
+Fixes a bug where if a facet contained multiple words it failed

--- a/packages/instant-meilisearch/src/adapter/search-request-adapter/__tests__/search-params.test.ts
+++ b/packages/instant-meilisearch/src/adapter/search-request-adapter/__tests__/search-params.test.ts
@@ -26,12 +26,23 @@ describe('Parameters adapter', () => {
     })
 
     expect(searchParams.filter).toStrictEqual([
-      ['genres="Drama"', 'genres="Thriller"'],
-      ['title="Ariel"'],
+      ['"genres"="Drama"', '"genres"="Thriller"'],
+      ['"title"="Ariel"'],
     ])
     expect(searchParams.sort).toStrictEqual(['id < 1'])
     expect(searchParams.attributesToHighlight).toContain('*')
     expect(searchParams.attributesToHighlight?.length).toBe(1)
+  })
+
+  test('adapting multi-word filters', () => {
+    const searchParams = adaptSearchParams({
+      ...DEFAULT_CONTEXT,
+      facetFilters: [['My Genre:Science Fiction']],
+    })
+
+    expect(searchParams.filter).toStrictEqual([
+      ['"My Genre"="Science Fiction"'],
+    ])
   })
 
   test('adapting a searchContext with matching strategy', () => {
@@ -55,8 +66,8 @@ describe('Geo filter adapter', () => {
 
     expect(searchParams.filter).toStrictEqual([
       '_geoBoundingBox([0, 0], [0, 0])',
-      ['genres="Drama"', 'genres="Thriller"'],
-      ['title="Ariel"'],
+      ['"genres"="Drama"', '"genres"="Thriller"'],
+      ['"title"="Ariel"'],
     ])
     expect(searchParams.sort).toStrictEqual(['id < 1'])
     expect(searchParams.attributesToHighlight).toContain('*')
@@ -72,8 +83,8 @@ describe('Geo filter adapter', () => {
 
     expect(searchParams.filter).toEqual([
       '_geoBoundingBox([0, 0], [0, 0])',
-      ['genres="Drama"', 'genres="Thriller"'],
-      ['title="Ariel"'],
+      ['"genres"="Drama"', '"genres"="Thriller"'],
+      ['"title"="Ariel"'],
     ])
     expect(searchParams.attributesToHighlight).toContain('*')
     expect(searchParams.attributesToHighlight?.length).toBe(1)

--- a/packages/instant-meilisearch/src/utils/string.ts
+++ b/packages/instant-meilisearch/src/utils/string.ts
@@ -7,15 +7,6 @@ export function isString(str: any): boolean {
 }
 
 /**
- * @param  {string} filter
- * @returns {string}
- */
-export function replaceColonByEqualSign(filter: string): string {
-  // will only change first occurence of `:`
-  return filter.replace(/:(.*)/i, '="$1"')
-}
-
-/**
  * @param  {any[]} arr
  * @returns {string}
  */


### PR DESCRIPTION
fixes: #1083 

Facets containing multiple words, for example `In stock`, were wrongly formatted. Meilisearch requires multi-words in filters to be wrapped in double quotes. The solution provided is to wrap every facet attribute and facet value in double quotes.

Before:
'In stock="value"'
After
'"In stock"="value"'

