### PR TITLE
Upgrade node version in CI workflows

### DIFF
--- a/.github/workflows/meilisearch-prototype-tests.yml
+++ b/.github/workflows/meilisearch-prototype-tests.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: yarn
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: yarn
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
           registry-url: https://registry.npmjs.org/
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: yarn
       - name: Install dependencies
         run: yarn
@@ -109,7 +109,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: yarn
       - name: Install dependencies
         run: yarn install
@@ -127,7 +127,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: yarn
       - name: Install dependencies
         run: yarn


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #1119 

## What does this PR do?
Upgrade node version in CI workflows (from node 16 to node 18) in following files:
- .github/workflows/meilisearch-prototype-tests.yml
- .github/workflows/pre-release-tests.yml
- .github/workflows/publish.yml
- .github/workflows/tests.yml

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
