### PR TITLE
Update meilisearch js to v0.33.0

### DIFF
--- a/packages/instant-meilisearch/__tests__/snippets.test.ts
+++ b/packages/instant-meilisearch/__tests__/snippets.test.ts
@@ -214,7 +214,7 @@ describe('Snippet Browser test', () => {
       {
         indexName: 'movies',
         params: {
-          query: 'm',
+          query: 'night',
           attributesToSnippet: ['overview:1', 'title:1'],
           snippetEllipsisText: '…',
         },
@@ -223,16 +223,16 @@ describe('Snippet Browser test', () => {
 
     const firstHit = response.results[0]?.hits[0]?._snippetResult
     expect(firstHit).toHaveProperty('title', {
-      value: '__ais-highlight__M__/ais-highlight__agnetic…',
+      value: '…__ais-highlight__Night__/ais-highlight__',
     })
-    expect(firstHit).toHaveProperty('overview', { value: '' })
+    expect(firstHit).toHaveProperty('overview', { value: 'While…' })
 
     const secondHit = response.results[0].hits[1]._snippetResult
     expect(secondHit).toHaveProperty('title', {
-      value: 'Judgment…',
+      value: 'Four…',
     })
     expect(secondHit).toHaveProperty('overview', {
-      value: '…__ais-highlight__m__/ais-highlight__atch…',
+      value: '…__ais-highlight__night__/ais-highlight__…',
     })
   })
 

--- a/packages/instant-meilisearch/package.json
+++ b/packages/instant-meilisearch/package.json
@@ -47,7 +47,7 @@
     "templates"
   ],
   "dependencies": {
-    "meilisearch": "^0.32.1"
+    "meilisearch": "^0.33.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.21.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5229,12 +5229,12 @@ critters@0.0.16:
     postcss "^8.3.7"
     pretty-bytes "^5.3.0"
 
-cross-fetch@^3.1.5:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
-  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+cross-fetch@^3.1.6:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.6.tgz#bae05aa31a4da760969756318feeee6e70f15d6c"
+  integrity sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==
   dependencies:
-    node-fetch "2.6.7"
+    node-fetch "^2.6.11"
 
 cross-spawn@^5.1.0:
   version "5.1.0"
@@ -9756,12 +9756,12 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
 
-meilisearch@^0.32.1:
-  version "0.32.1"
-  resolved "https://registry.yarnpkg.com/meilisearch/-/meilisearch-0.32.1.tgz#3b09a3d2a5d70949c38f410a53c22f0136d4e8f6"
-  integrity sha512-ceC0TSKL7GF91b50y1Qb2lKUUF/d5uZ242Iry093cTDRO3KfL/lcSwXxNxKzluk71iBPH0A0cKAIy6v06sPriA==
+meilisearch@^0.33.0:
+  version "0.33.0"
+  resolved "https://registry.yarnpkg.com/meilisearch/-/meilisearch-0.33.0.tgz#25982b193cdd22e9ec534a022dbde89c42951dc4"
+  integrity sha512-bYPb9WyITnJfzf92e7QFK8Rc50DmshFWxypXCs3ILlpNh8pT15A7KSu9Xgnnk/K3G/4vb3wkxxtFS4sxNkWB8w==
   dependencies:
-    cross-fetch "^3.1.5"
+    cross-fetch "^3.1.6"
 
 memfs@^3.4.12, memfs@^3.4.3:
   version "3.4.13"
@@ -10194,10 +10194,10 @@ node-addon-api@^3.0.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
   integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
 
-node-fetch@2.6.7:
-  version "2.6.7"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
-  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+node-fetch@^2.6.11:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.11.tgz#cde7fc71deef3131ef80a738919f999e6edfff25"
+  integrity sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==
   dependencies:
     whatwg-url "^5.0.0"
 


### PR DESCRIPTION
Update meilisearch-js to v0.33.0 and fix a failing tests introduced by the new version of Meilisearch (the engine) v1.2.0.

This failing test is due to a change in the way the cropping is processed on Meilisearch sides and is considered not a breaking change.
The test was changed to be more robust.