### PR TITLE
Make autocomplete public on npm

### DIFF
--- a/packages/autocomplete-client/package.json
+++ b/packages/autocomplete-client/package.json
@@ -3,6 +3,10 @@
   "version": "0.2.1",
   "private": false,
   "description": "The search client to use Meilisearch with autocomplete.js.",
+  "homepage": "https://github.com/meilisearch/instant-meilisearch/tree/main/packages/autocomplete-client",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "clear_jest": "jest --clearCache",
     "cleanup": "shx rm -rf dist/",
@@ -44,9 +48,6 @@
   },
   "dependencies": {
     "@meilisearch/instant-meilisearch": "*"
-  },
-  "peerDependencies": {
-    "@algolia/autocomplete-js": "^1.7.4"
   },
   "devDependencies": {
     "@algolia/autocomplete-js": "^1.7.4",


### PR DESCRIPTION
the autocomplete-client was added to npm as a private package, making it impossible to access without the writes on the package.