### PR TITLE
Fix the publish CI not running on a prototype

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
       - main
       - 'pre-release-beta/**'
       - 'beta/**'
-      - 'prototype-beta/'
+      - 'prototype-beta/**'
 env:
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
Missing wildcards resulted in the publishing CI not triggering on prototype versions.