### PR TITLE
Change GITHUB_TOKEN secret for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,6 @@ jobs:
           publish: yarn release
           version: yarn version-packages
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.MEILI_BOT_GH_PAT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Try to fix bug of CI not running

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release publishing workflow to use a new authentication token for creating release PRs or publishing to npm. This improves reliability of the release process without altering application behavior.

* **No User-Facing Changes**
  * No features, fixes, or UI updates in this release. No action required for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->