### PR TITLE
Use meilisearch EE 

### DIFF
--- a/.github/scripts/prototype-docker-version.sh
+++ b/.github/scripts/prototype-docker-version.sh
@@ -15,6 +15,6 @@ prototype_branch=$1                                                        # $GI
 prototype_branch=$(echo $prototype_branch | sed -r 's/prototype-beta\///') # remove pre-prending prototype-beta/
 prototype_name=$(echo $prototype_branch | sed -r 's/-beta//')              # remove appended -beta
 
-docker_image=$(curl "https://hub.docker.com/v2/repositories/getmeili/meilisearch/tags?&page_size=100" | jq | grep "$prototype_name" | head -1)
+docker_image=$(curl "https://hub.docker.com/v2/repositories/getmeili/meilisearch-enterprise/tags?&page_size=100" | jq | grep "$prototype_name" | head -1)
 docker_image=$(echo $docker_image | grep '"name":' | cut -d ':' -f 2- | tr -d ' ' | tr -d '"' | tr -d ',')
 echo $docker_image

--- a/.github/workflows/meilisearch-prototype-tests.yml
+++ b/.github/workflows/meilisearch-prototype-tests.yml
@@ -34,7 +34,7 @@ jobs:
     needs: ['meilisearch-version']
     services:
       meilisearch:
-        image: getmeili/meilisearch:${{ needs.meilisearch-version.outputs.version }}
+        image: getmeili/meilisearch-enterprise:${{ needs.meilisearch-version.outputs.version }}
         env:
           MEILI_MASTER_KEY: 'masterKey'
           MEILI_NO_ANALYTICS: 'true'
@@ -74,7 +74,7 @@ jobs:
     needs: ['meilisearch-version']
     services:
       meilisearch:
-        image: getmeili/meilisearch:${{ needs.meilisearch-version.outputs.version }}
+        image: getmeili/meilisearch-enterprise:${{ needs.meilisearch-version.outputs.version }}
         env:
           MEILI_MASTER_KEY: 'masterKey'
           MEILI_NO_ANALYTICS: 'true'
@@ -114,7 +114,7 @@ jobs:
     needs: ['meilisearch-version']
     services:
       meilisearch:
-        image: getmeili/meilisearch:${{ needs.meilisearch-version.outputs.version }}
+        image: getmeili/meilisearch-enterprise:${{ needs.meilisearch-version.outputs.version }}
         env:
           MEILI_MASTER_KEY: 'masterKey'
           MEILI_NO_ANALYTICS: 'true'

--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -32,7 +32,7 @@ jobs:
     needs: ['meilisearch-version']
     services:
       meilisearch:
-        image: getmeili/meilisearch:${{ needs.meilisearch-version.outputs.version }}
+        image: getmeili/meilisearch-enterprise:${{ needs.meilisearch-version.outputs.version }}
         env:
           MEILI_MASTER_KEY: 'masterKey'
           MEILI_NO_ANALYTICS: 'true'
@@ -73,7 +73,7 @@ jobs:
     needs: ['meilisearch-version']
     services:
       meilisearch:
-        image: getmeili/meilisearch:${{ needs.meilisearch-version.outputs.version }}
+        image: getmeili/meilisearch-enterprise:${{ needs.meilisearch-version.outputs.version }}
         env:
           MEILI_MASTER_KEY: 'masterKey'
           MEILI_NO_ANALYTICS: 'true'
@@ -114,7 +114,7 @@ jobs:
     needs: ['meilisearch-version']
     services:
       meilisearch:
-        image: getmeili/meilisearch:${{ needs.meilisearch-version.outputs.version }}
+        image: getmeili/meilisearch-enterprise:${{ needs.meilisearch-version.outputs.version }}
         env:
           MEILI_MASTER_KEY: 'masterKey'
           MEILI_NO_ANALYTICS: 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
       !startsWith(github.head_ref, 'pre-release-beta/')
     services:
       meilisearch:
-        image: getmeili/meilisearch:latest
+        image: getmeili/meilisearch-enterprise:latest
         env:
           MEILI_MASTER_KEY: 'masterKey'
           MEILI_NO_ANALYTICS: 'true'
@@ -73,7 +73,7 @@ jobs:
       !startsWith(github.head_ref, 'pre-release-beta/')
     services:
       meilisearch:
-        image: getmeili/meilisearch:latest
+        image: getmeili/meilisearch-enterprise:latest
         env:
           MEILI_MASTER_KEY: 'masterKey'
           MEILI_NO_ANALYTICS: 'true'
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       meilisearch:
-        image: getmeili/meilisearch:latest
+        image: getmeili/meilisearch-enterprise:latest
         env:
           MEILI_MASTER_KEY: 'masterKey'
           MEILI_NO_ANALYTICS: 'true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,8 +38,8 @@ Each PR should pass the tests and the linter to be accepted.
 
 ```bash
 # Tests with Vitest
-docker pull getmeili/meilisearch:latest # Fetch the latest version of Meilisearch image from Docker Hub
-docker run -p 7700:7700 getmeili/meilisearch:latest meilisearch --master-key=masterKey --no-analytics
+docker pull getmeili/meilisearch-enterprise:latest # Fetch the latest version of Meilisearch image from Docker Hub
+docker run -p 7700:7700 getmeili/meilisearch-enterprise:latest meilisearch --master-key=masterKey --no-analytics
 # Integration tests
 yarn test
 # End-to-end tests
@@ -191,7 +191,7 @@ Here are the steps to release a beta version of this package depending on its ty
     - Meilisearch `pre-release beta`: create a branch originating from `bump-meilisearch-v*.*.*` named `pre-release-beta/v*.*.*`. <br>
       Example: `pre-release-beta/v0.30.0`
     - Meilisearch `prototype beta`: create a branch `prototype-beta/xx-xx`. Where `xxx` has the same name as the docker image containing the prototype.
-        Example: If the [docker image](https://hub.docker.com/r/getmeili/meilisearch/tags) is named: `prototype-multi-search-0`, the branch should be named: `prototype-beta/prototype-multi-search`
+        Example: If the [docker image](https://hub.docker.com/r/getmeili/meilisearch-enterprise/tags) is named: `prototype-multi-search-0`, the branch should be named: `prototype-beta/prototype-multi-search`
 
 2. Enable the pre-release mode by running `yarn changeset pre enter [X]`. `X` is the part after the `/` of your beta branch. Example for `beta/refactor`, X would be `refactor`. This will create a `pre.json` file in `.changesets` that must be pushed on your beta branch.
 


### PR DESCRIPTION
Starting from [Meilisearch v1.28](https://github.com/meilisearch/meilisearch/releases/tag/v1.28.0), the community and enterprise editions of Meilisearch have distinct binaries.

To allow full-feature coverage, this PR updates the repository to test against the enterprise edition instead of the default community edition by using the `getmeili/meilisearch-enterprise` Docker image.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines with revised Docker commands using the enterprise image variant for development workflows.

* **Chores**
  * Updated GitHub Actions workflows and build scripts to use the enterprise Docker image across testing jobs and deployment pipelines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->