### PR TITLE
Configure trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     name: Release & Version
     runs-on: ubuntu-latest
     outputs:
-      published: ${{ steps.changesets.outputs.published }}
+      hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v5
@@ -38,7 +38,7 @@ jobs:
     name: Publish to npm (OIDC)
     needs: release
     # Only run if Changesets indicates there are packages to publish
-    if: needs.release.outputs.published == 'true'
+    if: needs.release.outputs.hasChangesets == 'false'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -46,13 +46,12 @@ jobs:
         with:
           node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
+      - name: Upgrade npm for OIDC
+        run: npm install -g npm@latest
       - name: Install dependencies
         run: yarn install
       - name: Build packages
         run: yarn build
-      - name: Enable provenance
-        # changeset publish calls npm publish internally without --provenance
-        run: echo "provenance=true" >> .npmrc
       - name: Publish packages
         # No NPM_TOKEN env here - uses OIDC token from id-token: write permission
         run: yarn changeset publish


### PR DESCRIPTION
# Pull Request

## What does this PR do?
- Update the `publish.yml` workflow to [allow generating OIDC tokens](https://docs.npmjs.com/trusted-publishers#github-actions-configuration)

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow split into separate release and publish jobs; release job renamed and exposes hasChangesets output.
  * Triggers broadened and a permissions block (contents/id-token: write) added.
  * Publish job runs conditionally based on release output and uses OIDC-based publishing (no inline token files).
  * Runtime and install steps updated (Node 24.x, yarn install); build and provenance-enabled publish steps added.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->