### PR TITLE
Rename to lower case s Meilisearch

### DIFF
--- a/.changeset/wild-cooks-stand.md
+++ b/.changeset/wild-cooks-stand.md
@@ -1,0 +1,16 @@
+---
+'@meilisearch/autocomplete-client': minor
+'@meilisearch/instant-meilisearch': minor
+---
+
+# Rename MeiliSearch to Meilisearch
+
+- Following https://github.com/meilisearch/meilisearch-js/pull/2144 rename every uppercase "S" in "\*MeiliSearch\*" to lower case "s"
+
+## Migration
+
+```diff
+- import { instantMeiliSearch } from "@meilisearch/instant-meilisearch";
++ import { instantMeilisearch } from "@meilisearch/instant-meilisearch";
+// ... same pattern for every other export
+```

--- a/package.json
+++ b/package.json
@@ -76,5 +76,5 @@
     "vue": "3.5.25",
     "vue-instantsearch": "4.22.6"
   },
-  "packageManager": "pnpm@10.26.0"
+  "packageManager": "pnpm@10.33.0"
 }

--- a/packages/autocomplete-client/README.md
+++ b/packages/autocomplete-client/README.md
@@ -134,7 +134,7 @@ The `options` field in the `meilisearchAutocompleteClient` function provides the
 - [`keepZeroFacets`](#keep-zero-facets): Show the facets value even when they have 0 matches (default `false`).
 - [`requestConfig`](#request-config): Use custom request configurations.
 - [`httpClient`](#custom-http-client): Use a custom HTTP client.
-- [`meiliSearchParams`](#meilisearch-search-parameters): Override search parameters sent to Meilisearch.
+- [`meilisearchParams`](#meilisearch-search-parameters): Override search parameters sent to Meilisearch.
 
 ```js
 const client = meilisearchAutocompleteClient({
@@ -142,7 +142,7 @@ const client = meilisearchAutocompleteClient({
   apiKey: 'searchKey',
   options: {
     // other options
-    meiliSearchParams: {
+    meilisearchParams: {
     },
   },
 })
@@ -228,7 +228,7 @@ You can use your own HTTP client, for example, with [`axios`](https://github.com
 
 ### Meilisearch search parameters
 
-`meiliSearchParams` lets you override the parameters sent to Meilisearch.
+`meilisearchParams` lets you override the parameters sent to Meilisearch.
 The following options can be overridden:
 - [`attributesToCrop`](https://www.meilisearch.com/docs/reference/api/search?utm_campaign=oss&utm_source=github&utm_medium=instant-meilisearch#attributes-to-crop)
 - [`attributesToHighlight`](https://www.meilisearch.com/docs/reference/api/search?utm_campaign=oss&utm_source=github&utm_medium=instant-meilisearch#attributes-to-highlight)

--- a/packages/autocomplete-client/__tests__/test.utils.ts
+++ b/packages/autocomplete-client/__tests__/test.utils.ts
@@ -12,7 +12,7 @@ const searchClient = meilisearchAutocompleteClient({
   apiKey: API_KEY,
 })
 
-const meilisearchClient = new meilisearch.MeiliSearch({
+const meilisearchClient = new meilisearch.Meilisearch({
   host: 'http://localhost:7700',
   apiKey: 'masterKey',
 })

--- a/packages/autocomplete-client/src/client/createSearchClient.ts
+++ b/packages/autocomplete-client/src/client/createSearchClient.ts
@@ -1,4 +1,4 @@
-import { instantMeiliSearch } from '@meilisearch/instant-meilisearch'
+import { instantMeilisearch } from '@meilisearch/instant-meilisearch'
 import type { SearchClient } from '../types/SearchClient.js'
 import type { ClientConfig } from '../types/ClientConfig.js'
 
@@ -14,7 +14,7 @@ export function createSearchClient({ userAgent }: { userAgent: string }) {
     options = { clientAgents: [] },
   }: ClientConfig): SearchClient => {
     const clientAgents = options.clientAgents || []
-    const { searchClient } = instantMeiliSearch(url, apiKey, {
+    const { searchClient } = instantMeilisearch(url, apiKey, {
       ...options,
       clientAgents: concatUserAgents([userAgent, ...clientAgents]),
     })

--- a/packages/autocomplete-client/src/types/ClientConfig.ts
+++ b/packages/autocomplete-client/src/types/ClientConfig.ts
@@ -1,7 +1,7 @@
-import { instantMeiliSearch } from '@meilisearch/instant-meilisearch'
+import { instantMeilisearch } from '@meilisearch/instant-meilisearch'
 import type { MeilisearchOptions } from './MeilisearchOptions.js'
 
-export type InstantMeilisearch = typeof instantMeiliSearch
+export type InstantMeilisearch = typeof instantMeilisearch
 export type MeilisearchURL = Parameters<InstantMeilisearch>[0]
 export type MeilisearchApiKey = Parameters<InstantMeilisearch>[1]
 export type ClientConfig = {

--- a/packages/autocomplete-client/src/types/MeilisearchOptions.ts
+++ b/packages/autocomplete-client/src/types/MeilisearchOptions.ts
@@ -1,3 +1,3 @@
-import type { InstantMeiliSearchOptions } from '@meilisearch/instant-meilisearch'
+import type { InstantMeilisearchOptions } from '@meilisearch/instant-meilisearch'
 
-export type MeilisearchOptions = InstantMeiliSearchOptions
+export type MeilisearchOptions = InstantMeilisearchOptions

--- a/packages/autocomplete-client/src/types/SearchClient.ts
+++ b/packages/autocomplete-client/src/types/SearchClient.ts
@@ -1,3 +1,3 @@
-import type { InstantMeiliSearchInstance } from '@meilisearch/instant-meilisearch'
+import type { InstantMeilisearchInstance } from '@meilisearch/instant-meilisearch'
 
-export type SearchClient = InstantMeiliSearchInstance
+export type SearchClient = InstantMeilisearchInstance

--- a/packages/instant-meilisearch/README.md
+++ b/packages/instant-meilisearch/README.md
@@ -159,7 +159,7 @@ where `searchClient` is to be passed to instantsearch.js or its many framework a
 - [`keepZeroFacets`](#keep-zero-facets): Show the facets value even when they have 0 matches (default `false`).
 - [`requestInit`](#request-config): Use custom request configurations.
 - [`httpClient`](#custom-http-client): Use a custom HTTP client.
-- [`meiliSearchParams`](#meilisearch-search-parameters): Override a selection of Meilisearch search parameters (default `undefined`).
+- [`meilisearchParams`](#meilisearch-search-parameters): Override a selection of Meilisearch search parameters (default `undefined`).
 
 The options are added as the third parameter of the `instantMeilisearch` function.
 
@@ -382,7 +382,7 @@ const { searchClient } = instantMeilisearch(
 
 ### Meilisearch search parameters
 
-`meiliSearchParams` lets you override a set of search parameters that are sent off to Meilisearch.
+`meilisearchParams` lets you override a set of search parameters that are sent off to Meilisearch.
 The following options can be overridden:
 - [`attributesToCrop`](https://www.meilisearch.com/docs/reference/api/search?utm_campaign=oss&utm_source=github&utm_medium=instant-meilisearch#attributes-to-crop)
 - [`attributesToHighlight`](https://www.meilisearch.com/docs/reference/api/search?utm_campaign=oss&utm_source=github&utm_medium=instant-meilisearch#attributes-to-highlight)
@@ -402,7 +402,7 @@ The following options can be overridden:
 instantMeilisearch(
   // ...
   {
-    meiliSearchParams: {
+    meilisearchParams: {
       attributesToHighlight: ['overview'],
       highlightPreTag: '<em>',
       highlightPostTag: '</em>',
@@ -417,7 +417,7 @@ When using multi search, meilisearchParams can be overriden for specific indexes
 instantMeilisearch(
   // ...
   {
-    meiliSearchParams: {
+    meilisearchParams: {
       // All indexes will highlight overview
       attributesToHighlight: ['overview'],
       highlightPreTag: '<em>',
@@ -448,7 +448,7 @@ It only modifies parameters that are defined on the provided object, the followi
 const { setMeilisearchParams } = instantMeilisearch(
   // ...
   {
-    meiliSearchParams: {
+    meilisearchParams: {
       attributesToHighlight: ['overview'],
       highlightPreTag: '<em>',
       highlightPostTag: '</em>',

--- a/packages/instant-meilisearch/README.md
+++ b/packages/instant-meilisearch/README.md
@@ -134,15 +134,15 @@ To be able to create a search interface, you'll need to [install `instantsearch.
 ### Basic
 
 ```js
-import { instantMeiliSearch } from '@meilisearch/instant-meilisearch'
+import { instantMeilisearch } from '@meilisearch/instant-meilisearch'
 
-const { searchClient, setMeiliSearchParams } = instantMeiliSearch(
+const { searchClient, setMeilisearchParams } = instantMeilisearch(
   'https://ms-adf78ae33284-106.lon.meilisearch.io', // Host
   'a63da4928426f12639e19d62886f621130f3fa9ff3c7534c5d179f0f51c4f303' // API key
 )
 ```
 
-where `searchClient` is to be passed to instantsearch.js or its many framework adaptations, and [`setMeiliSearchParams`](#modify-meilisearch-search-parameters) is a function used to set/modify certain Meilisearch search parameters to be overridden.
+where `searchClient` is to be passed to instantsearch.js or its many framework adaptations, and [`setMeilisearchParams`](#modify-meilisearch-search-parameters) is a function used to set/modify certain Meilisearch search parameters to be overridden.
 
 ### Parameters
 
@@ -164,9 +164,9 @@ where `searchClient` is to be passed to instantsearch.js or its many framework a
 The options are added as the third parameter of the `instantMeilisearch` function.
 
 ```js
-import { instantMeiliSearch } from '@meilisearch/instant-meilisearch'
+import { instantMeilisearch } from '@meilisearch/instant-meilisearch'
 
-const { searchClient } = instantMeiliSearch(
+const { searchClient } = instantMeilisearch(
   'https://ms-adf78ae33284-106.lon.meilisearch.io',
   'a63da4928426f12639e19d62886f621130f3fa9ff3c7534c5d179f0f51c4f303',
   {
@@ -277,10 +277,10 @@ Search metadata is useful for interacting with the [Meilisearch Analytics Events
 The search client returns `MeilisearchSearchResponse` which extends the standard `AlgoliaSearchResponse` with an optional `_meilisearch` namespace containing metadata:
 
 ```ts
-import { instantMeiliSearch, getAnalyticsMetadata } from '@meilisearch/instant-meilisearch'
+import { instantMeilisearch, getAnalyticsMetadata } from '@meilisearch/instant-meilisearch'
 import instantsearch from 'instantsearch.js'
 
-const { searchClient } = instantMeiliSearch(
+const { searchClient } = instantMeilisearch(
   'https://ms-adf78ae33284-106.lon.meilisearch.io',
   'a63da4928426f12639e19d62886f621130f3fa9ff3c7534c5d179f0f51c4f303'
 )
@@ -367,7 +367,7 @@ connectHits(renderHits)
 For self-hosted Meilisearch instances, you need to enable search metadata by setting the `Meili-Include-Metadata` header:
 
 ```ts
-const { searchClient } = instantMeiliSearch(
+const { searchClient } = instantMeilisearch(
   'http://localhost:7700',
   'your-api-key',
   {
@@ -399,7 +399,7 @@ The following options can be overridden:
 - [`rankingScoreThreshold`](https://www.meilisearch.com/docs/reference/api/search?utm_campaign=oss&utm_source=github&utm_medium=instant-meilisearch#ranking-score-threshold)
 
 ```js
-instantMeiliSearch(
+instantMeilisearch(
   // ...
   {
     meiliSearchParams: {
@@ -414,7 +414,7 @@ instantMeiliSearch(
 When using multi search, meilisearchParams can be overriden for specific indexes :
 
 ```js
-instantMeiliSearch(
+instantMeilisearch(
   // ...
   {
     meiliSearchParams: {
@@ -435,17 +435,17 @@ instantMeiliSearch(
 ```
 ### Modify Meilisearch search parameters
 
-`instantMeiliSearch` returns an instance with two properties on it, one of them being `setMeiliSearchParams`.
+`instantMeilisearch` returns an instance with two properties on it, one of them being `setMeilisearchParams`.
 
 ```js
-const { searchClient, setMeiliSearchParams } = instantMeiliSearch(/*...*/)
+const { searchClient, setMeilisearchParams } = instantMeilisearch(/*...*/)
 ```
 
 It modifies (or sets if not already set) the [overridden Meilisearch search parameters](#meilisearch-search-parameters).
 It only modifies parameters that are defined on the provided object, the following will not change `attributesToHighlight`.
 
 ```js
-const { setMeiliSearchParams } = instantMeiliSearch(
+const { setMeilisearchParams } = instantMeilisearch(
   // ...
   {
     meiliSearchParams: {
@@ -457,7 +457,7 @@ const { setMeiliSearchParams } = instantMeiliSearch(
   }
 )
 
-setMeiliSearchParams({
+setMeilisearchParams({
   highlightPreTag: '<mark>',
   highlightPostTag: '</mark>',
   attributesToSearchOn: ['overview', 'title'],
@@ -495,7 +495,7 @@ In `index.html`:
 In `app.js`:
 
 ```js
-const { searchClient } = instantMeiliSearch(
+const { searchClient } = instantMeilisearch(
   'https://ms-adf78ae33284-106.lon.meilisearch.io',
   'a63da4928426f12639e19d62886f621130f3fa9ff3c7534c5d179f0f51c4f303'
 )
@@ -620,11 +620,11 @@ List of all the components that are available in [instantSearch](https://github.
 ```js
 const search = instantsearch({
   indexName: 'instant_search',
-  searchClient: instantMeiliSearch(
+  searchClient: instantMeilisearch(
     'https://ms-adf78ae33284-106.lon.meilisearch.io',
     'a63da4928426f12639e19d62886f621130f3fa9ff3c7534c5d179f0f51c4f303',
     {
-      // ... InstantMeiliSearch options
+      // ... InstantMeilisearch options
     }
   ).searchClient,
   // ... InstantSearch options

--- a/packages/instant-meilisearch/__tests__/assets/utils.ts
+++ b/packages/instant-meilisearch/__tests__/assets/utils.ts
@@ -1,5 +1,5 @@
-import { instantMeiliSearch } from '../../src/index.js'
-import { MeiliSearch } from 'meilisearch'
+import { instantMeilisearch } from '../../src/index.js'
+import { Meilisearch } from 'meilisearch'
 
 const HOST = 'http://localhost:7700'
 const API_KEY = 'masterKey'
@@ -309,15 +309,15 @@ export type Movies = {
   _highlightResult?: Movies
 }
 
-const { searchClient } = instantMeiliSearch(
+const { searchClient } = instantMeilisearch(
   'http://localhost:7700',
   'masterKey'
 )
-const { searchClient: wrongSearchClient } = instantMeiliSearch(
+const { searchClient: wrongSearchClient } = instantMeilisearch(
   'http://localhost:7777',
   'masterKey'
 )
-const meilisearchClient = new MeiliSearch({
+const meilisearchClient = new Meilisearch({
   host: HOST,
   apiKey: API_KEY,
 })

--- a/packages/instant-meilisearch/__tests__/custom-http-client.test.ts
+++ b/packages/instant-meilisearch/__tests__/custom-http-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, beforeAll, test, expect, vi } from 'vitest'
-import { instantMeiliSearch } from '../src/index.js'
+import { instantMeilisearch } from '../src/index.js'
 import { meilisearchClient, dataset } from './assets/utils.js'
 
 describe('Custom HTTP client tests', () => {
@@ -18,7 +18,7 @@ describe('Custom HTTP client tests', () => {
       return await result.json()
     })
 
-    const { searchClient } = instantMeiliSearch(
+    const { searchClient } = instantMeilisearch(
       'http://localhost:7700',
       'masterKey',
       {

--- a/packages/instant-meilisearch/__tests__/disjunctive-facet-search.test.ts
+++ b/packages/instant-meilisearch/__tests__/disjunctive-facet-search.test.ts
@@ -1,5 +1,5 @@
 import { describe, beforeAll, test, expect } from 'vitest'
-import { instantMeiliSearch } from '../src/index.js'
+import { instantMeilisearch } from '../src/index.js'
 import { type Movies, meilisearchClient } from './assets/utils.js'
 import movies from './assets/movies.json' with { type: 'json' }
 import games from './assets/games.json' with { type: 'json' }
@@ -26,7 +26,7 @@ describe('Keep zero facets tests', () => {
   })
 
   test('searching on one index with facet filtering', async () => {
-    const { searchClient: customClient } = instantMeiliSearch(
+    const { searchClient: customClient } = instantMeilisearch(
       'http://localhost:7700',
       'masterKey',
       {
@@ -94,7 +94,7 @@ describe('Keep zero facets tests', () => {
   })
 
   test('searching on two indexes with facet filtering', async () => {
-    const { searchClient: customClient } = instantMeiliSearch(
+    const { searchClient: customClient } = instantMeilisearch(
       'http://localhost:7700',
       'masterKey',
       {
@@ -242,7 +242,7 @@ describe('Keep zero facets tests', () => {
   })
 
   test('searching on two indexes with facet filtering and keep zero facets', async () => {
-    const { searchClient: customClient } = instantMeiliSearch(
+    const { searchClient: customClient } = instantMeilisearch(
       'http://localhost:7700',
       'masterKey',
       {
@@ -412,7 +412,7 @@ describe('Keep zero facets tests', () => {
   })
 
   test('searching on an index with facet filtering with some and operators', async () => {
-    const { searchClient: customClient } = instantMeiliSearch(
+    const { searchClient: customClient } = instantMeilisearch(
       'http://localhost:7700',
       'masterKey',
       {
@@ -463,7 +463,7 @@ describe('Keep zero facets tests', () => {
   })
 
   test('searching on an index with facet filtering with some and operators with keep zero facets', async () => {
-    const { searchClient: customClient } = instantMeiliSearch(
+    const { searchClient: customClient } = instantMeilisearch(
       'http://localhost:7700',
       'masterKey',
       {

--- a/packages/instant-meilisearch/__tests__/first-facets-distribution.test.ts
+++ b/packages/instant-meilisearch/__tests__/first-facets-distribution.test.ts
@@ -1,6 +1,6 @@
 import { describe, beforeAll, test, expect } from 'vitest'
 import { dataset, meilisearchClient, HOST, API_KEY } from './assets/utils.js'
-import { instantMeiliSearch } from '../src/index.js'
+import { instantMeilisearch } from '../src/index.js'
 
 describe('Default facet distribution', () => {
   beforeAll(async () => {
@@ -20,7 +20,7 @@ describe('Default facet distribution', () => {
   // With placeholderSearch
   // With empty query
   test('creation of facet distribution without facets', async () => {
-    const { searchClient } = instantMeiliSearch(HOST, API_KEY)
+    const { searchClient } = instantMeilisearch(HOST, API_KEY)
     const response = await searchClient.search([
       {
         indexName: 'movies',
@@ -38,7 +38,7 @@ describe('Default facet distribution', () => {
   // With placeholderSearch
   // With empty query
   test('creation of facet distribution without facets and with keepZeroFacets to true', async () => {
-    const { searchClient } = instantMeiliSearch(HOST, API_KEY, {
+    const { searchClient } = instantMeilisearch(HOST, API_KEY, {
       keepZeroFacets: true,
     })
     const response = await searchClient.search([
@@ -58,7 +58,7 @@ describe('Default facet distribution', () => {
   // without placeholderSearch
   // With multiple searchs
   test('creation of facet distribution with facets, with keepZeroFacets to false and placeholdersearch to false', async () => {
-    const { searchClient } = instantMeiliSearch(HOST, API_KEY, {
+    const { searchClient } = instantMeilisearch(HOST, API_KEY, {
       keepZeroFacets: false,
       placeholderSearch: false, // only test false since `true` is default value
     })
@@ -102,7 +102,7 @@ describe('Default facet distribution', () => {
   })
 
   test('creation of facet distribution when using indexes with sort-by', async () => {
-    const { searchClient } = instantMeiliSearch(HOST, API_KEY)
+    const { searchClient } = instantMeilisearch(HOST, API_KEY)
     const releaseDateDistribution = {
       release_date: {
         '1065744000': 1,
@@ -143,7 +143,7 @@ describe('Default facet distribution', () => {
   })
 
   test('creation of facet distribution when using indexes with sort-by and keepZeroFacets', async () => {
-    const { searchClient } = instantMeiliSearch(HOST, API_KEY, {
+    const { searchClient } = instantMeilisearch(HOST, API_KEY, {
       keepZeroFacets: true,
     })
     const releaseDateDistribution = {
@@ -186,7 +186,7 @@ describe('Default facet distribution', () => {
   })
 
   test('creation of facet distribution when using indexes with sort-by and no placeholdersearch', async () => {
-    const { searchClient } = instantMeiliSearch(HOST, API_KEY, {
+    const { searchClient } = instantMeilisearch(HOST, API_KEY, {
       placeholderSearch: false,
     })
     const releaseDateDistribution = {
@@ -233,7 +233,7 @@ describe('Default facet distribution', () => {
   // with placeholderSearch
   // With empty query
   test('creation of facet distribution with facets', async () => {
-    const { searchClient } = instantMeiliSearch(HOST, API_KEY)
+    const { searchClient } = instantMeilisearch(HOST, API_KEY)
     const response = await searchClient.search([
       {
         indexName: 'movies',
@@ -277,7 +277,7 @@ describe('Default facet distribution', () => {
   // with placeholderSearch
   // With multiple search (empty and no results expected)
   test('Ensure cached facetDistribution works between two searches when keepZeroFacets is true', async () => {
-    const { searchClient } = instantMeiliSearch(HOST, API_KEY, {
+    const { searchClient } = instantMeilisearch(HOST, API_KEY, {
       keepZeroFacets: true,
     })
     const response = await searchClient.search([
@@ -331,7 +331,7 @@ describe('Default facet distribution', () => {
   // without placeholderSearch
   // With multiple search (empty and no results expected)
   test('ensure cached facetDistribution works between two calls when placeholderSearch is false', async () => {
-    const { searchClient } = instantMeiliSearch(HOST, API_KEY, {
+    const { searchClient } = instantMeilisearch(HOST, API_KEY, {
       keepZeroFacets: true,
       placeholderSearch: false,
     })
@@ -389,7 +389,7 @@ describe('Default facet distribution', () => {
   // Without multiple search
   // Without query expecting no results
   test('creation of facet distribution with facets, keepZeroFacets to true, and query', async () => {
-    const { searchClient } = instantMeiliSearch(HOST, API_KEY, {
+    const { searchClient } = instantMeilisearch(HOST, API_KEY, {
       keepZeroFacets: true,
     })
     const response = await searchClient.search([

--- a/packages/instant-meilisearch/__tests__/instantiation.test.ts
+++ b/packages/instant-meilisearch/__tests__/instantiation.test.ts
@@ -1,9 +1,9 @@
 import { describe, test, expect } from 'vitest'
-import { instantMeiliSearch } from '../src/index.js'
+import { instantMeilisearch } from '../src/index.js'
 
-describe('InstantMeiliSearch instantiation', () => {
-  test('instantiation with required params returns InstantMeiliSearchInstance', () => {
-    const searchClient = instantMeiliSearch(
+describe('InstantMeilisearch instantiation', () => {
+  test('instantiation with required params returns InstantMeilisearchInstance', () => {
+    const searchClient = instantMeilisearch(
       'http://localhost:7700',
       'masterKey'
     )
@@ -11,8 +11,8 @@ describe('InstantMeiliSearch instantiation', () => {
     expect(searchClient).toBeTruthy()
   })
 
-  test('instantiation with function as apiKey returns InstantMeiliSearchInstance', () => {
-    const searchClient = instantMeiliSearch('http://localhost:7700', () => {
+  test('instantiation with function as apiKey returns InstantMeilisearchInstance', () => {
+    const searchClient = instantMeilisearch('http://localhost:7700', () => {
       return 'masterKey'
     })
 
@@ -22,28 +22,28 @@ describe('InstantMeiliSearch instantiation', () => {
   test('instantiation without hostUrl throws error', () => {
     expect(() => {
       // @ts-expect-error
-      instantMeiliSearch(undefined, 'masterKey')
+      instantMeilisearch(undefined, 'masterKey')
     }).toThrow(TypeError)
   })
 
   test('instantiation without apiKey as function or string throws error', () => {
     expect(() => {
       // @ts-expect-error
-      instantMeiliSearch('http://localhost:7700', 123)
+      instantMeilisearch('http://localhost:7700', 123)
     }).toThrow(TypeError)
   })
 
   test('instantiation with function that does not return string as apiKey throws error', () => {
     expect(() => {
       // @ts-expect-error
-      instantMeiliSearch('http://localhost:7700', () => {
+      instantMeilisearch('http://localhost:7700', () => {
         return 123
       })
     }).toThrow(TypeError)
   })
 
   test('instantiation with custom request config with correct type', () => {
-    const searchClient = instantMeiliSearch('http://localhost:7700', '', {
+    const searchClient = instantMeilisearch('http://localhost:7700', '', {
       requestInit: {},
     })
 
@@ -51,7 +51,7 @@ describe('InstantMeiliSearch instantiation', () => {
   })
 
   test('instantiation with custom request config set to undefined', () => {
-    const searchClient = instantMeiliSearch('http://localhost:7700', '', {
+    const searchClient = instantMeilisearch('http://localhost:7700', '', {
       requestInit: undefined,
     })
 
@@ -60,7 +60,7 @@ describe('InstantMeiliSearch instantiation', () => {
 
   test('instantiation with custom request config set to a string', () => {
     expect(() => {
-      instantMeiliSearch('http://localhost:7700', '', {
+      instantMeilisearch('http://localhost:7700', '', {
         // @ts-expect-error
         requestInit: '',
       })
@@ -68,7 +68,7 @@ describe('InstantMeiliSearch instantiation', () => {
   })
 
   test('instantiation with custom HTTP client with correct type', () => {
-    const searchClient = instantMeiliSearch('http://localhost:7700', '', {
+    const searchClient = instantMeilisearch('http://localhost:7700', '', {
       httpClient: async () => {
         return new Promise((resolve) => {
           resolve({})
@@ -80,7 +80,7 @@ describe('InstantMeiliSearch instantiation', () => {
   })
 
   test('instantiation with custom HTTP client set to undefined', () => {
-    const searchClient = instantMeiliSearch('http://localhost:7700', '', {
+    const searchClient = instantMeilisearch('http://localhost:7700', '', {
       httpClient: undefined,
     })
 
@@ -89,7 +89,7 @@ describe('InstantMeiliSearch instantiation', () => {
 
   test('instantiation with custom HTTP client set to a string', () => {
     expect(() => {
-      instantMeiliSearch('http://localhost:7700', '', {
+      instantMeilisearch('http://localhost:7700', '', {
         // @ts-expect-error
         httpClient: 'wrong type',
       })

--- a/packages/instant-meilisearch/__tests__/multi-index-search.test.ts
+++ b/packages/instant-meilisearch/__tests__/multi-index-search.test.ts
@@ -1,5 +1,5 @@
 import { describe, beforeAll, test, expect } from 'vitest'
-import { instantMeiliSearch } from '../src/index.js'
+import { instantMeilisearch } from '../src/index.js'
 import { type Movies, meilisearchClient } from './assets/utils.js'
 import movies from './assets/movies.json' with { type: 'json' }
 import games from './assets/games.json' with { type: 'json' }
@@ -28,7 +28,7 @@ describe('Multi-index search test', () => {
   })
 
   test('searching on two indexes', async () => {
-    const { searchClient: customClient } = instantMeiliSearch(
+    const { searchClient: customClient } = instantMeilisearch(
       'http://localhost:7700',
       'masterKey'
     )
@@ -56,7 +56,7 @@ describe('Multi-index search test', () => {
   })
 
   test('searching on two indexes with scroll pagination', async () => {
-    const { searchClient: customClient } = instantMeiliSearch(
+    const { searchClient: customClient } = instantMeilisearch(
       'http://localhost:7700',
       'masterKey'
     )
@@ -91,7 +91,7 @@ describe('Multi-index search test', () => {
   })
 
   test('searching on two indexes with page selection pagination', async () => {
-    const { searchClient: customClient } = instantMeiliSearch(
+    const { searchClient: customClient } = instantMeilisearch(
       'http://localhost:7700',
       'masterKey',
       {
@@ -129,7 +129,7 @@ describe('Multi-index search test', () => {
   })
 
   test('searching on two indexes with facet filtering', async () => {
-    const { searchClient: customClient } = instantMeiliSearch(
+    const { searchClient: customClient } = instantMeilisearch(
       'http://localhost:7700',
       'masterKey'
     )
@@ -225,7 +225,7 @@ describe('Multi-index search test', () => {
   })
 
   test('searching on two indexes with no placeholder search', async () => {
-    const { searchClient: customClient } = instantMeiliSearch(
+    const { searchClient: customClient } = instantMeilisearch(
       'http://localhost:7700',
       'masterKey',
       {

--- a/packages/instant-meilisearch/__tests__/overridden-meilisearch-parameters.test.ts
+++ b/packages/instant-meilisearch/__tests__/overridden-meilisearch-parameters.test.ts
@@ -13,7 +13,7 @@ describe('InstantMeilisearch overridden parameters', () => {
       'http://localhost:7700',
       'masterKey',
       {
-        meiliSearchParams: {
+        meilisearchParams: {
           highlightPreTag: '<em>',
           highlightPostTag: '</em>',
           attributesToSearchOn: ['overview'],
@@ -74,7 +74,7 @@ describe('InstantMeilisearch overridden parameters', () => {
       'http://localhost:7700',
       'masterKey',
       {
-        meiliSearchParams: {
+        meilisearchParams: {
           sort: ['title:asc'],
         },
       }

--- a/packages/instant-meilisearch/__tests__/overridden-meilisearch-parameters.test.ts
+++ b/packages/instant-meilisearch/__tests__/overridden-meilisearch-parameters.test.ts
@@ -1,15 +1,15 @@
 import { describe, beforeAll, test, expect } from 'vitest'
-import { instantMeiliSearch } from '../src/index.js'
+import { instantMeilisearch } from '../src/index.js'
 import { dataset, meilisearchClient, type Movies } from './assets/utils.js'
 
-describe('InstantMeiliSearch overridden parameters', () => {
+describe('InstantMeilisearch overridden parameters', () => {
   beforeAll(async () => {
     await meilisearchClient.deleteIndex('movies').waitTask()
     await meilisearchClient.index('movies').addDocuments(dataset).waitTask()
   })
 
   test('instantiating with, and changing overridden Meilisearch parameters', async () => {
-    const { searchClient, setMeiliSearchParams } = instantMeiliSearch(
+    const { searchClient, setMeilisearchParams } = instantMeilisearch(
       'http://localhost:7700',
       'masterKey',
       {
@@ -35,7 +35,7 @@ describe('InstantMeiliSearch overridden parameters', () => {
       '<em>While racing to a boxing match</em>'
     )
 
-    setMeiliSearchParams({
+    setMeilisearchParams({
       highlightPreTag: '<om>',
       highlightPostTag: '</om>',
     })
@@ -48,7 +48,7 @@ describe('InstantMeiliSearch overridden parameters', () => {
       '<om>While racing to a boxing match</om>'
     )
 
-    setMeiliSearchParams({
+    setMeilisearchParams({
       indexesOverrides: {
         movies: { highlightPreTag: '<span>', highlightPostTag: '</span>' },
       },
@@ -70,7 +70,7 @@ describe('InstantMeiliSearch overridden parameters', () => {
       })
       .waitTask()
 
-    const { searchClient, setMeiliSearchParams } = instantMeiliSearch(
+    const { searchClient, setMeilisearchParams } = instantMeilisearch(
       'http://localhost:7700',
       'masterKey',
       {
@@ -98,7 +98,7 @@ describe('InstantMeiliSearch overridden parameters', () => {
     expect(globalTitles).toEqual([...globalTitles].sort())
 
     // Test per-index sort override takes precedence over global
-    setMeiliSearchParams({
+    setMeilisearchParams({
       sort: ['title:asc'],
       indexesOverrides: {
         movies: { sort: ['title:desc'] },

--- a/packages/instant-meilisearch/__tests__/placeholder-search.test.ts
+++ b/packages/instant-meilisearch/__tests__/placeholder-search.test.ts
@@ -1,5 +1,5 @@
 import { describe, beforeAll, test, expect } from 'vitest'
-import { instantMeiliSearch } from '../src/index.js'
+import { instantMeilisearch } from '../src/index.js'
 import { dataset, type Movies, meilisearchClient } from './assets/utils.js'
 
 describe('Pagination browser test', () => {
@@ -13,7 +13,7 @@ describe('Pagination browser test', () => {
   })
 
   test('placeholdersearch set to true', async () => {
-    const { searchClient: customClient } = instantMeiliSearch(
+    const { searchClient: customClient } = instantMeilisearch(
       'http://localhost:7700',
       'masterKey',
       {
@@ -32,7 +32,7 @@ describe('Pagination browser test', () => {
   })
 
   test('placeholdersearch set to false', async () => {
-    const { searchClient: customClient } = instantMeiliSearch(
+    const { searchClient: customClient } = instantMeilisearch(
       'http://localhost:7700',
       'masterKey',
       {
@@ -51,7 +51,7 @@ describe('Pagination browser test', () => {
   })
 
   test('placeholdersearch with query', async () => {
-    const { searchClient: customClient } = instantMeiliSearch(
+    const { searchClient: customClient } = instantMeilisearch(
       'http://localhost:7700',
       'masterKey',
       {
@@ -73,7 +73,7 @@ describe('Pagination browser test', () => {
   })
 
   test('placeholdersearch set to false with filter', async () => {
-    const { searchClient: customClient } = instantMeiliSearch(
+    const { searchClient: customClient } = instantMeilisearch(
       'http://localhost:7700',
       'masterKey',
       {

--- a/packages/instant-meilisearch/__tests__/search-metadata.test.ts
+++ b/packages/instant-meilisearch/__tests__/search-metadata.test.ts
@@ -1,5 +1,5 @@
 import { describe, beforeAll, test, expect } from 'vitest'
-import { instantMeiliSearch, getAnalyticsMetadata } from '../src/index.js'
+import { instantMeilisearch, getAnalyticsMetadata } from '../src/index.js'
 import { dataset, type Movies, meilisearchClient } from './assets/utils.js'
 
 describe('Search metadata integration tests', () => {
@@ -9,7 +9,7 @@ describe('Search metadata integration tests', () => {
   })
 
   test('metadata is present when Meili-Include-Metadata header is set', async () => {
-    const { searchClient } = instantMeiliSearch(
+    const { searchClient } = instantMeilisearch(
       'http://localhost:7700',
       'masterKey',
       {
@@ -44,7 +44,7 @@ describe('Search metadata integration tests', () => {
   })
 
   test('metadata is accessible via getAnalyticsMetadata helper', async () => {
-    const { searchClient } = instantMeiliSearch(
+    const { searchClient } = instantMeilisearch(
       'http://localhost:7700',
       'masterKey',
       {
@@ -86,7 +86,7 @@ describe('Search metadata integration tests', () => {
   })
 
   test('metadata is not present when header is not set', async () => {
-    const { searchClient } = instantMeiliSearch(
+    const { searchClient } = instantMeilisearch(
       'http://localhost:7700',
       'masterKey'
     )
@@ -107,7 +107,7 @@ describe('Search metadata integration tests', () => {
   })
 
   test('getAnalyticsMetadata returns undefined when metadata is not present', async () => {
-    const { searchClient } = instantMeiliSearch(
+    const { searchClient } = instantMeilisearch(
       'http://localhost:7700',
       'masterKey'
     )

--- a/packages/instant-meilisearch/__tests__/search-resolver.test.ts
+++ b/packages/instant-meilisearch/__tests__/search-resolver.test.ts
@@ -17,9 +17,9 @@ export const searchResponse = {
 
 vi.mock(import('meilisearch'), { spy: true })
 
-function getMeilisearchMultiSearchSpy(meiliSearch: Meilisearch) {
+function getMeilisearchMultiSearchSpy(meilisearch: Meilisearch) {
   return vi
-    .spyOn(meiliSearch, 'multiSearch')
+    .spyOn(meilisearch, 'multiSearch')
     .mockImplementation(function (request) {
       const response = request.queries.map(
         (req: MeilisearchMultiSearchParams) => ({
@@ -46,10 +46,10 @@ describe('Cached search tests', () => {
         query: '',
       },
     }
-    const { searchClient, meiliSearchInstance } = instantMeilisearch(
+    const { searchClient, meilisearchInstance } = instantMeilisearch(
       'http://localhost:7700'
     )
-    const mockedMultiSearch = getMeilisearchMultiSearchSpy(meiliSearchInstance)
+    const mockedMultiSearch = getMeilisearchMultiSearchSpy(meilisearchInstance)
 
     await searchClient.search<Movies>([searchParameters])
     await searchClient.search<Movies>([searchParameters])
@@ -76,10 +76,10 @@ describe('Cached search tests', () => {
         query: 'other query',
       },
     }
-    const { searchClient, meiliSearchInstance } = instantMeilisearch(
+    const { searchClient, meilisearchInstance } = instantMeilisearch(
       'http://localhost:7700'
     )
-    const mockedMultiSearch = getMeilisearchMultiSearchSpy(meiliSearchInstance)
+    const mockedMultiSearch = getMeilisearchMultiSearchSpy(meilisearchInstance)
 
     await searchClient.search<Movies>([searchParameters1])
     await searchClient.search<Movies>([searchParameters2])
@@ -106,10 +106,10 @@ describe('Cached search tests', () => {
         query: 'other query',
       },
     }
-    const { searchClient, meiliSearchInstance } = instantMeilisearch(
+    const { searchClient, meilisearchInstance } = instantMeilisearch(
       'http://localhost:7700'
     )
-    const mockedMultiSearch = getMeilisearchMultiSearchSpy(meiliSearchInstance)
+    const mockedMultiSearch = getMeilisearchMultiSearchSpy(meilisearchInstance)
 
     await searchClient.search<Movies>([searchParameters1])
     await searchClient.search<Movies>([searchParameters2])
@@ -137,10 +137,10 @@ describe('Cached search tests', () => {
         query: 'other query',
       },
     }
-    const { searchClient, meiliSearchInstance } = instantMeilisearch(
+    const { searchClient, meilisearchInstance } = instantMeilisearch(
       'http://localhost:7700'
     )
-    const mockedMultiSearch = getMeilisearchMultiSearchSpy(meiliSearchInstance)
+    const mockedMultiSearch = getMeilisearchMultiSearchSpy(meilisearchInstance)
 
     await searchClient.search<Movies>([searchParameters1])
     await searchClient.search<Movies>([searchParameters2])
@@ -177,10 +177,10 @@ describe('Cached search tests', () => {
         query: 'other query',
       },
     }
-    const { searchClient, meiliSearchInstance } = instantMeilisearch(
+    const { searchClient, meilisearchInstance } = instantMeilisearch(
       'http://localhost:7700'
     )
-    const mockedMultiSearch = getMeilisearchMultiSearchSpy(meiliSearchInstance)
+    const mockedMultiSearch = getMeilisearchMultiSearchSpy(meilisearchInstance)
 
     await searchClient.search<Movies>(searchParameters1)
     await searchClient.search<Movies>([searchParameters2])

--- a/packages/instant-meilisearch/__tests__/search-resolver.test.ts
+++ b/packages/instant-meilisearch/__tests__/search-resolver.test.ts
@@ -1,9 +1,9 @@
 import { describe, afterEach, test, expect, vi } from 'vitest'
 import type { Movies } from './assets/utils.js'
-import { instantMeiliSearch } from '../src/index.js'
-import { MeiliSearch } from 'meilisearch'
+import { instantMeilisearch } from '../src/index.js'
+import { Meilisearch } from 'meilisearch'
 import { PACKAGE_VERSION } from '../src/package-version.js'
-import type { MeiliSearchMultiSearchParams } from '../src/types/index.js'
+import type { MeilisearchMultiSearchParams } from '../src/types/index.js'
 
 export const searchResponse = {
   hits: [],
@@ -17,12 +17,12 @@ export const searchResponse = {
 
 vi.mock(import('meilisearch'), { spy: true })
 
-function getMeiliSearchMultiSearchSpy(meiliSearch: MeiliSearch) {
+function getMeilisearchMultiSearchSpy(meiliSearch: Meilisearch) {
   return vi
     .spyOn(meiliSearch, 'multiSearch')
     .mockImplementation(function (request) {
       const response = request.queries.map(
-        (req: MeiliSearchMultiSearchParams) => ({
+        (req: MeilisearchMultiSearchParams) => ({
           ...searchResponse,
           indexUid: req.indexUid,
         })
@@ -46,15 +46,15 @@ describe('Cached search tests', () => {
         query: '',
       },
     }
-    const { searchClient, meiliSearchInstance } = instantMeiliSearch(
+    const { searchClient, meiliSearchInstance } = instantMeilisearch(
       'http://localhost:7700'
     )
-    const mockedMultiSearch = getMeiliSearchMultiSearchSpy(meiliSearchInstance)
+    const mockedMultiSearch = getMeilisearchMultiSearchSpy(meiliSearchInstance)
 
     await searchClient.search<Movies>([searchParameters])
     await searchClient.search<Movies>([searchParameters])
 
-    expect(MeiliSearch).toHaveBeenCalledWith({
+    expect(Meilisearch).toHaveBeenCalledWith({
       host: 'http://localhost:7700',
       apiKey: '',
       clientAgents: [`Meilisearch instant-meilisearch (v${PACKAGE_VERSION})`],
@@ -76,15 +76,15 @@ describe('Cached search tests', () => {
         query: 'other query',
       },
     }
-    const { searchClient, meiliSearchInstance } = instantMeiliSearch(
+    const { searchClient, meiliSearchInstance } = instantMeilisearch(
       'http://localhost:7700'
     )
-    const mockedMultiSearch = getMeiliSearchMultiSearchSpy(meiliSearchInstance)
+    const mockedMultiSearch = getMeilisearchMultiSearchSpy(meiliSearchInstance)
 
     await searchClient.search<Movies>([searchParameters1])
     await searchClient.search<Movies>([searchParameters2])
 
-    expect(MeiliSearch).toHaveBeenCalledWith({
+    expect(Meilisearch).toHaveBeenCalledWith({
       host: 'http://localhost:7700',
       apiKey: '',
       clientAgents: [`Meilisearch instant-meilisearch (v${PACKAGE_VERSION})`],
@@ -106,16 +106,16 @@ describe('Cached search tests', () => {
         query: 'other query',
       },
     }
-    const { searchClient, meiliSearchInstance } = instantMeiliSearch(
+    const { searchClient, meiliSearchInstance } = instantMeilisearch(
       'http://localhost:7700'
     )
-    const mockedMultiSearch = getMeiliSearchMultiSearchSpy(meiliSearchInstance)
+    const mockedMultiSearch = getMeilisearchMultiSearchSpy(meiliSearchInstance)
 
     await searchClient.search<Movies>([searchParameters1])
     await searchClient.search<Movies>([searchParameters2])
     await searchClient.search<Movies>([searchParameters1])
 
-    expect(MeiliSearch).toHaveBeenCalledWith({
+    expect(Meilisearch).toHaveBeenCalledWith({
       host: 'http://localhost:7700',
       apiKey: '',
       clientAgents: [`Meilisearch instant-meilisearch (v${PACKAGE_VERSION})`],
@@ -137,17 +137,17 @@ describe('Cached search tests', () => {
         query: 'other query',
       },
     }
-    const { searchClient, meiliSearchInstance } = instantMeiliSearch(
+    const { searchClient, meiliSearchInstance } = instantMeilisearch(
       'http://localhost:7700'
     )
-    const mockedMultiSearch = getMeiliSearchMultiSearchSpy(meiliSearchInstance)
+    const mockedMultiSearch = getMeilisearchMultiSearchSpy(meiliSearchInstance)
 
     await searchClient.search<Movies>([searchParameters1])
     await searchClient.search<Movies>([searchParameters2])
     await searchClient.search<Movies>([searchParameters1])
     await searchClient.search<Movies>([searchParameters2])
 
-    expect(MeiliSearch).toHaveBeenCalledWith({
+    expect(Meilisearch).toHaveBeenCalledWith({
       host: 'http://localhost:7700',
       apiKey: '',
       clientAgents: [`Meilisearch instant-meilisearch (v${PACKAGE_VERSION})`],
@@ -177,17 +177,17 @@ describe('Cached search tests', () => {
         query: 'other query',
       },
     }
-    const { searchClient, meiliSearchInstance } = instantMeiliSearch(
+    const { searchClient, meiliSearchInstance } = instantMeilisearch(
       'http://localhost:7700'
     )
-    const mockedMultiSearch = getMeiliSearchMultiSearchSpy(meiliSearchInstance)
+    const mockedMultiSearch = getMeilisearchMultiSearchSpy(meiliSearchInstance)
 
     await searchClient.search<Movies>(searchParameters1)
     await searchClient.search<Movies>([searchParameters2])
     await searchClient.search<Movies>(searchParameters1)
     await searchClient.search<Movies>([searchParameters2])
 
-    expect(MeiliSearch).toHaveBeenCalledWith({
+    expect(Meilisearch).toHaveBeenCalledWith({
       host: 'http://localhost:7700',
       apiKey: '',
       clientAgents: [`Meilisearch instant-meilisearch (v${PACKAGE_VERSION})`],

--- a/packages/instant-meilisearch/src/adapter/search-request-adapter/__tests__/search-params.test.ts
+++ b/packages/instant-meilisearch/src/adapter/search-request-adapter/__tests__/search-params.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect } from 'vitest'
 import { MatchingStrategies } from 'meilisearch'
 import { adaptSearchParams } from '../search-params-adapter.js'
 import type {
-  OverridableMeiliSearchSearchParameters,
+  OverridableMeilisearchSearchParameters,
   SearchContext,
 } from '../../../types/index.js'
 
@@ -54,7 +54,7 @@ describe('Parameters adapter', () => {
   })
 
   test('adapting a searchContext with overridden Meilisearch parameters', () => {
-    const meiliSearchParams: OverridableMeiliSearchSearchParameters = {
+    const meiliSearchParams: OverridableMeilisearchSearchParameters = {
       attributesToHighlight: ['movies', 'genres'],
       highlightPreTag: '<em>',
       highlightPostTag: '</em>',
@@ -81,7 +81,7 @@ describe('Parameters adapter', () => {
   })
 
   test('adapting a searchContext with overridden Meilisearch parameters for a specific index', () => {
-    const meiliSearchParams: OverridableMeiliSearchSearchParameters = {
+    const meiliSearchParams: OverridableMeilisearchSearchParameters = {
       attributesToHighlight: ['movies', 'genres'],
       highlightPreTag: '<em>',
       highlightPostTag: '</em>',

--- a/packages/instant-meilisearch/src/adapter/search-request-adapter/__tests__/search-params.test.ts
+++ b/packages/instant-meilisearch/src/adapter/search-request-adapter/__tests__/search-params.test.ts
@@ -54,7 +54,7 @@ describe('Parameters adapter', () => {
   })
 
   test('adapting a searchContext with overridden Meilisearch parameters', () => {
-    const meiliSearchParams: OverridableMeilisearchSearchParameters = {
+    const meilisearchParams: OverridableMeilisearchSearchParameters = {
       attributesToHighlight: ['movies', 'genres'],
       highlightPreTag: '<em>',
       highlightPostTag: '</em>',
@@ -63,25 +63,25 @@ describe('Parameters adapter', () => {
 
     const searchParams = adaptSearchParams({
       ...DEFAULT_CONTEXT,
-      meiliSearchParams,
+      meilisearchParams,
     })
 
     expect(searchParams.attributesToHighlight).toEqual(
-      meiliSearchParams.attributesToHighlight
+      meilisearchParams.attributesToHighlight
     )
     expect(searchParams.highlightPreTag).toEqual(
-      meiliSearchParams.highlightPreTag
+      meilisearchParams.highlightPreTag
     )
     expect(searchParams.highlightPostTag).toEqual(
-      meiliSearchParams.highlightPostTag
+      meilisearchParams.highlightPostTag
     )
     expect(searchParams.matchingStrategy).toEqual(
-      meiliSearchParams.matchingStrategy
+      meilisearchParams.matchingStrategy
     )
   })
 
   test('adapting a searchContext with overridden Meilisearch parameters for a specific index', () => {
-    const meiliSearchParams: OverridableMeilisearchSearchParameters = {
+    const meilisearchParams: OverridableMeilisearchSearchParameters = {
       attributesToHighlight: ['movies', 'genres'],
       highlightPreTag: '<em>',
       highlightPostTag: '</em>',
@@ -98,20 +98,20 @@ describe('Parameters adapter', () => {
 
     const searchParams = adaptSearchParams({
       ...DEFAULT_CONTEXT,
-      meiliSearchParams,
+      meilisearchParams,
     })
 
     expect(searchParams.attributesToHighlight).toEqual(
-      meiliSearchParams.indexesOverrides?.test?.attributesToHighlight
+      meilisearchParams.indexesOverrides?.test?.attributesToHighlight
     )
     expect(searchParams.highlightPreTag).toEqual(
-      meiliSearchParams.indexesOverrides?.test?.highlightPreTag
+      meilisearchParams.indexesOverrides?.test?.highlightPreTag
     )
     expect(searchParams.highlightPostTag).toEqual(
-      meiliSearchParams.indexesOverrides?.test?.highlightPostTag
+      meilisearchParams.indexesOverrides?.test?.highlightPostTag
     )
     expect(searchParams.matchingStrategy).toEqual(
-      meiliSearchParams.indexesOverrides?.test?.matchingStrategy
+      meilisearchParams.indexesOverrides?.test?.matchingStrategy
     )
   })
 
@@ -123,7 +123,7 @@ describe('Parameters adapter', () => {
 
     const searchParams = adaptSearchParams({
       ...DEFAULT_CONTEXT,
-      meiliSearchParams: {
+      meilisearchParams: {
         hybrid: hybridSearchConfig,
       },
     })
@@ -143,7 +143,7 @@ describe('Parameters adapter', () => {
 
     const searchParams = adaptSearchParams({
       ...DEFAULT_CONTEXT,
-      meiliSearchParams: {
+      meilisearchParams: {
         hybrid: hybridSearchConfig,
         indexesOverrides: {
           test: { hybrid: specificHybridSearchConfig },
@@ -159,7 +159,7 @@ describe('Parameters adapter', () => {
 
     const searchParams = adaptSearchParams({
       ...DEFAULT_CONTEXT,
-      meiliSearchParams: {
+      meilisearchParams: {
         vector,
       },
     })
@@ -172,7 +172,7 @@ describe('Parameters adapter', () => {
 
     const searchParams = adaptSearchParams({
       ...DEFAULT_CONTEXT,
-      meiliSearchParams: {
+      meilisearchParams: {
         vector,
         indexesOverrides: { test: { vector: indexVector } },
       },
@@ -186,7 +186,7 @@ describe('Parameters adapter', () => {
 
     const searchParams = adaptSearchParams({
       ...DEFAULT_CONTEXT,
-      meiliSearchParams: {
+      meilisearchParams: {
         rankingScoreThreshold,
       },
     })
@@ -200,7 +200,7 @@ describe('Parameters adapter', () => {
 
     const searchParams = adaptSearchParams({
       ...DEFAULT_CONTEXT,
-      meiliSearchParams: {
+      meilisearchParams: {
         rankingScoreThreshold,
         indexesOverrides: {
           test: { rankingScoreThreshold: indexRankingScoreThreshold },
@@ -216,7 +216,7 @@ describe('Parameters adapter', () => {
 
     const searchParams = adaptSearchParams({
       ...DEFAULT_CONTEXT,
-      meiliSearchParams: {
+      meilisearchParams: {
         distinct: distinctSearchConfig,
       },
     })
@@ -230,7 +230,7 @@ describe('Parameters adapter', () => {
 
     const searchParams = adaptSearchParams({
       ...DEFAULT_CONTEXT,
-      meiliSearchParams: {
+      meilisearchParams: {
         distinct: distinctSearchConfig,
         indexesOverrides: {
           test: { distinct: indexDistinctSearchConfig },
@@ -247,7 +247,7 @@ describe('Parameters adapter', () => {
     const searchParams = adaptSearchParams({
       ...DEFAULT_CONTEXT,
       // No facetFilters, filters, or numericFilters - empty IS filters
-      meiliSearchParams: {
+      meilisearchParams: {
         filter: globalFilter,
       },
     })
@@ -262,7 +262,7 @@ describe('Parameters adapter', () => {
     const searchParams = adaptSearchParams({
       ...DEFAULT_CONTEXT,
       // No facetFilters, filters, or numericFilters - empty IS filters
-      meiliSearchParams: {
+      meilisearchParams: {
         filter: globalFilter,
         indexesOverrides: {
           test: { filter: indexFilter },

--- a/packages/instant-meilisearch/src/adapter/search-request-adapter/search-params-adapter.ts
+++ b/packages/instant-meilisearch/src/adapter/search-request-adapter/search-params-adapter.ts
@@ -2,7 +2,7 @@ import type {
   SearchContext,
   Filter,
   PaginationState,
-  MeiliSearchMultiSearchParams,
+  MeilisearchMultiSearchParams,
   Mutable,
 } from '../../types/index.js'
 
@@ -84,12 +84,12 @@ export function MeiliParamsCreator(searchContext: SearchContext) {
     restrictSearchableAttributes,
     meiliSearchParams: overrideParams,
   } = searchContext
-  const meiliSearchParams: MeiliSearchMultiSearchParams = { indexUid }
+  const meiliSearchParams: MeilisearchMultiSearchParams = { indexUid }
 
   const meilisearchFilters = adaptFilters(filters, numericFilters, facetFilters)
 
   return {
-    getParams(): MeiliSearchMultiSearchParams {
+    getParams(): MeilisearchMultiSearchParams {
       return meiliSearchParams
     },
     addQuery() {
@@ -305,11 +305,11 @@ export function MeiliParamsCreator(searchContext: SearchContext) {
  * Meilisearch
  *
  * @param {SearchContext} searchContext
- * @returns {MeiliSearchMultiSearchParams}
+ * @returns {MeilisearchMultiSearchParams}
  */
 export function adaptSearchParams(
   searchContext: SearchContext
-): MeiliSearchMultiSearchParams {
+): MeilisearchMultiSearchParams {
   const meilisearchParams = MeiliParamsCreator(searchContext)
   meilisearchParams.addQuery()
   meilisearchParams.addFacets()

--- a/packages/instant-meilisearch/src/adapter/search-request-adapter/search-params-adapter.ts
+++ b/packages/instant-meilisearch/src/adapter/search-request-adapter/search-params-adapter.ts
@@ -82,18 +82,18 @@ export function MeiliParamsCreator(searchContext: SearchContext) {
     pagination,
     sort,
     restrictSearchableAttributes,
-    meiliSearchParams: overrideParams,
+    meilisearchParams: overrideParams,
   } = searchContext
-  const meiliSearchParams: MeilisearchMultiSearchParams = { indexUid }
+  const meilisearchParams: MeilisearchMultiSearchParams = { indexUid }
 
   const meilisearchFilters = adaptFilters(filters, numericFilters, facetFilters)
 
   return {
     getParams(): MeilisearchMultiSearchParams {
-      return meiliSearchParams
+      return meilisearchParams
     },
     addQuery() {
-      meiliSearchParams.q = query
+      meilisearchParams.q = query
     },
     addFacets() {
       const value =
@@ -103,7 +103,7 @@ export function MeiliParamsCreator(searchContext: SearchContext) {
       if (value !== undefined) {
         // despite Instantsearch.js typing it as `string[]`,
         // it still can send `string`
-        meiliSearchParams.facets = typeof value === 'string' ? [value] : value
+        meilisearchParams.facets = typeof value === 'string' ? [value] : value
       }
     },
     addAttributesToCrop() {
@@ -112,7 +112,7 @@ export function MeiliParamsCreator(searchContext: SearchContext) {
         overrideParams?.attributesToCrop ??
         <Mutable<typeof attributesToSnippet>>attributesToSnippet
       if (value !== undefined) {
-        meiliSearchParams.attributesToCrop = value
+        meilisearchParams.attributesToCrop = value
       }
     },
     addCropLength() {
@@ -120,7 +120,7 @@ export function MeiliParamsCreator(searchContext: SearchContext) {
         overrideParams?.indexesOverrides?.[indexUid]?.cropLength ??
         overrideParams?.cropLength
       if (value !== undefined) {
-        meiliSearchParams.cropLength = value
+        meilisearchParams.cropLength = value
       }
     },
     addCropMarker() {
@@ -129,7 +129,7 @@ export function MeiliParamsCreator(searchContext: SearchContext) {
         overrideParams?.cropMarker ??
         snippetEllipsisText
       if (value !== undefined) {
-        meiliSearchParams.cropMarker = value
+        meilisearchParams.cropMarker = value
       }
     },
     addFilters() {
@@ -138,9 +138,9 @@ export function MeiliParamsCreator(searchContext: SearchContext) {
         overrideParams?.filter
 
       if (overrideFilter !== undefined) {
-        meiliSearchParams.filter = overrideFilter
+        meilisearchParams.filter = overrideFilter
       } else if (meilisearchFilters.length) {
-        meiliSearchParams.filter = meilisearchFilters
+        meilisearchParams.filter = meilisearchFilters
       }
     },
     addAttributesToRetrieve() {
@@ -149,24 +149,24 @@ export function MeiliParamsCreator(searchContext: SearchContext) {
         overrideParams?.attributesToRetrieve ??
         <Mutable<typeof attributesToRetrieve>>attributesToRetrieve
       if (value !== undefined) {
-        meiliSearchParams.attributesToRetrieve = value
+        meilisearchParams.attributesToRetrieve = value
       }
     },
     addAttributesToHighlight() {
-      meiliSearchParams.attributesToHighlight = overrideParams
+      meilisearchParams.attributesToHighlight = overrideParams
         ?.indexesOverrides?.[indexUid]?.attributesToHighlight ??
         overrideParams?.attributesToHighlight ??
         <Mutable<typeof attributesToHighlight>>attributesToHighlight ?? ['*']
     },
     addPreTag() {
-      meiliSearchParams.highlightPreTag =
+      meilisearchParams.highlightPreTag =
         overrideParams?.indexesOverrides?.[indexUid]?.highlightPreTag ??
         overrideParams?.highlightPreTag ??
         highlightPreTag ??
         '__ais-highlight__'
     },
     addPostTag() {
-      meiliSearchParams.highlightPostTag =
+      meilisearchParams.highlightPostTag =
         overrideParams?.indexesOverrides?.[indexUid]?.highlightPostTag ??
         overrideParams?.highlightPostTag ??
         highlightPostTag ??
@@ -183,15 +183,15 @@ export function MeiliParamsCreator(searchContext: SearchContext) {
           pagination,
           paginationRequired
         )
-        meiliSearchParams.hitsPerPage = hitsPerPage
-        meiliSearchParams.page = page
+        meilisearchParams.hitsPerPage = hitsPerPage
+        meilisearchParams.page = page
       } else {
         const { limit, offset } = setScrollPagination(
           pagination,
           paginationRequired
         )
-        meiliSearchParams.limit = limit
-        meiliSearchParams.offset = offset
+        meilisearchParams.limit = limit
+        meilisearchParams.offset = offset
       }
     },
     addSort() {
@@ -201,7 +201,7 @@ export function MeiliParamsCreator(searchContext: SearchContext) {
 
       const value = overrideSort ?? sort
       if (value && (Array.isArray(value) ? value.length : true)) {
-        meiliSearchParams.sort = Array.isArray(value) ? value : [value]
+        meilisearchParams.sort = Array.isArray(value) ? value : [value]
       }
     },
     addGeoSearchFilter() {
@@ -222,10 +222,10 @@ export function MeiliParamsCreator(searchContext: SearchContext) {
       })
 
       if (filter !== undefined) {
-        if (Array.isArray(meiliSearchParams.filter)) {
-          meiliSearchParams.filter.unshift(filter)
+        if (Array.isArray(meilisearchParams.filter)) {
+          meilisearchParams.filter.unshift(filter)
         } else {
-          meiliSearchParams.filter = [filter]
+          meilisearchParams.filter = [filter]
         }
       }
     },
@@ -234,7 +234,7 @@ export function MeiliParamsCreator(searchContext: SearchContext) {
         overrideParams?.indexesOverrides?.[indexUid]?.showMatchesPosition ??
         overrideParams?.showMatchesPosition
       if (value !== undefined) {
-        meiliSearchParams.showMatchesPosition = value
+        meilisearchParams.showMatchesPosition = value
       }
     },
     addMatchingStrategy() {
@@ -242,7 +242,7 @@ export function MeiliParamsCreator(searchContext: SearchContext) {
         overrideParams?.indexesOverrides?.[indexUid]?.matchingStrategy ??
         overrideParams?.matchingStrategy
       if (value !== undefined) {
-        meiliSearchParams.matchingStrategy = value
+        meilisearchParams.matchingStrategy = value
       }
     },
     addShowRankingScore() {
@@ -250,7 +250,7 @@ export function MeiliParamsCreator(searchContext: SearchContext) {
         overrideParams?.indexesOverrides?.[indexUid]?.showRankingScore ??
         overrideParams?.showRankingScore
       if (value !== undefined) {
-        meiliSearchParams.showRankingScore = value
+        meilisearchParams.showRankingScore = value
       }
     },
     addAttributesToSearchOn() {
@@ -262,7 +262,7 @@ export function MeiliParamsCreator(searchContext: SearchContext) {
         )
 
       if (value !== undefined) {
-        meiliSearchParams.attributesToSearchOn = value
+        meilisearchParams.attributesToSearchOn = value
       }
     },
     addHybridSearch() {
@@ -270,7 +270,7 @@ export function MeiliParamsCreator(searchContext: SearchContext) {
         overrideParams?.indexesOverrides?.[indexUid]?.hybrid ??
         overrideParams?.hybrid
       if (value !== undefined) {
-        meiliSearchParams.hybrid = value
+        meilisearchParams.hybrid = value
       }
     },
     addVector() {
@@ -278,7 +278,7 @@ export function MeiliParamsCreator(searchContext: SearchContext) {
         overrideParams?.indexesOverrides?.[indexUid]?.vector ??
         overrideParams?.vector
       if (value !== undefined) {
-        meiliSearchParams.vector = value
+        meilisearchParams.vector = value
       }
     },
     addDistinct() {
@@ -286,7 +286,7 @@ export function MeiliParamsCreator(searchContext: SearchContext) {
         overrideParams?.indexesOverrides?.[indexUid]?.distinct ??
         overrideParams?.distinct
       if (value !== undefined) {
-        meiliSearchParams.distinct = value
+        meilisearchParams.distinct = value
       }
     },
     addRankingScoreThreshold() {
@@ -294,7 +294,7 @@ export function MeiliParamsCreator(searchContext: SearchContext) {
         overrideParams?.indexesOverrides?.[indexUid]?.rankingScoreThreshold ??
         overrideParams?.rankingScoreThreshold
       if (value !== undefined) {
-        meiliSearchParams.rankingScoreThreshold = value
+        meilisearchParams.rankingScoreThreshold = value
       }
     },
   }

--- a/packages/instant-meilisearch/src/adapter/search-request-adapter/search-resolver.ts
+++ b/packages/instant-meilisearch/src/adapter/search-request-adapter/search-resolver.ts
@@ -1,19 +1,19 @@
 import type {
-  MeiliSearch,
+  Meilisearch,
   SearchCacheInterface,
-  MeiliSearchMultiSearchParams,
+  MeilisearchMultiSearchParams,
   MeilisearchMultiSearchResult,
   PaginationState,
 } from '../../types/index.js'
 
 /** @param {ResponseCacher} cache */
 export function SearchResolver(
-  client: MeiliSearch,
+  client: Meilisearch,
   cache: SearchCacheInterface
 ) {
   return {
     multiSearch: async function (
-      searchQueries: MeiliSearchMultiSearchParams[],
+      searchQueries: MeilisearchMultiSearchParams[],
       instantSearchPagination: PaginationState[]
     ): Promise<MeilisearchMultiSearchResult[]> {
       const key = cache.formatKey([searchQueries])

--- a/packages/instant-meilisearch/src/adapter/search-response-adapter/__tests__/hit-adapter.test.ts
+++ b/packages/instant-meilisearch/src/adapter/search-response-adapter/__tests__/hit-adapter.test.ts
@@ -162,7 +162,7 @@ const searchResponsePositionMatchesTrue = {
 }
 
 describe('Hit adapter', () => {
-  test('_matchesPosition should be created in hit object with meiliSearchParams.showMatchesPosition=true', () => {
+  test('_matchesPosition should be created in hit object with meilisearchParams.showMatchesPosition=true', () => {
     const expectedPositionMatch = {
       name: [
         {
@@ -177,7 +177,7 @@ describe('Hit adapter', () => {
       keepZeroFacets: false,
       clientAgents: [],
       finitePagination: true,
-      meiliSearchParams: {
+      meilisearchParams: {
         showMatchesPosition: true,
       },
     }
@@ -187,13 +187,13 @@ describe('Hit adapter', () => {
     expect(adaptedHits[0]._matchesPosition).toEqual(expectedPositionMatch)
   })
 
-  test('_matchesPosition should NOT be created in hit object with meiliSearchParams.showMatchesPosition=false', () => {
+  test('_matchesPosition should NOT be created in hit object with meilisearchParams.showMatchesPosition=false', () => {
     const config = {
       placeholderSearch: true,
       keepZeroFacets: false,
       clientAgents: [],
       finitePagination: true,
-      meiliSearchParams: {
+      meilisearchParams: {
         showMatchesPosition: false,
       },
     }

--- a/packages/instant-meilisearch/src/adapter/search-response-adapter/hits-adapter.ts
+++ b/packages/instant-meilisearch/src/adapter/search-response-adapter/hits-adapter.ts
@@ -42,7 +42,7 @@ export function adaptHits(
         adaptFormattedFields(formattedHit)
       )
 
-      if (config?.meiliSearchParams?.showMatchesPosition) {
+      if (config?.meilisearchParams?.showMatchesPosition) {
         adaptedHit._matchesPosition = _matchesPosition
       }
 

--- a/packages/instant-meilisearch/src/adapter/search-response-adapter/hits-adapter.ts
+++ b/packages/instant-meilisearch/src/adapter/search-response-adapter/hits-adapter.ts
@@ -1,7 +1,7 @@
 import type {
   PaginationState,
   MeilisearchMultiSearchResult,
-  InstantMeiliSearchConfig,
+  InstantMeilisearchConfig,
 } from '../../types/index.js'
 import { adaptFormattedFields } from './format-adapter/index.js'
 import { adaptGeoResponse } from './geo-reponse-adapter.js'
@@ -15,7 +15,7 @@ export function adaptHits(
   searchResponse: MeilisearchMultiSearchResult & {
     pagination: PaginationState
   },
-  config: InstantMeiliSearchConfig
+  config: InstantMeilisearchConfig
 ): any {
   const { hits } = searchResponse
   const { hitsPerPage, page } = searchResponse.pagination

--- a/packages/instant-meilisearch/src/adapter/search-response-adapter/search-response-adapter.ts
+++ b/packages/instant-meilisearch/src/adapter/search-response-adapter/search-response-adapter.ts
@@ -46,7 +46,7 @@ export function adaptSearchResults<T = Record<string, any>>(
  * @returns {MeilisearchSearchResponse<T>}
  */
 export function adaptSearchResult<T>(
-  meiliSearchResult: MeilisearchMultiSearchResult,
+  meilisearchResult: MeilisearchMultiSearchResult,
   initialFacetDistribution: FacetDistribution,
   config: InstantMeilisearchConfig
 ): MeilisearchSearchResponse<T> {
@@ -57,17 +57,17 @@ export function adaptSearchResult<T>(
     facetDistribution: responseFacetDistribution = {},
     facetStats = {},
     metadata,
-  } = meiliSearchResult
+  } = meilisearchResult
 
   const facets = Object.keys(responseFacetDistribution)
 
   const { hitsPerPage, page, nbPages } = adaptPaginationParameters(
-    meiliSearchResult,
-    meiliSearchResult.pagination
+    meilisearchResult,
+    meilisearchResult.pagination
   )
 
-  const hits = adaptHits(meiliSearchResult, config)
-  const nbHits = adaptTotalHits(meiliSearchResult)
+  const hits = adaptHits(meilisearchResult, config)
+  const nbHits = adaptTotalHits(meilisearchResult)
 
   const facetDistribution = adaptFacetDistribution(
     config.keepZeroFacets,

--- a/packages/instant-meilisearch/src/adapter/search-response-adapter/search-response-adapter.ts
+++ b/packages/instant-meilisearch/src/adapter/search-response-adapter/search-response-adapter.ts
@@ -1,6 +1,6 @@
 import type {
   FacetDistribution,
-  InstantMeiliSearchConfig,
+  InstantMeilisearchConfig,
   MeilisearchMultiSearchResult,
   MeilisearchSearchResponse,
 } from '../../types/index.js'
@@ -16,13 +16,13 @@ import { adaptFacetStats } from './adapt-facet-stats.js'
  *
  * @param {MeilisearchMultiSearchResult<T>[]} searchResponse
  * @param {Record<string, FacetDistribution>} initialFacetDistribution
- * @param {InstantMeiliSearchConfig} config
+ * @param {InstantMeilisearchConfig} config
  * @returns {{ results: MeilisearchSearchResponse<T>[] }}
  */
 export function adaptSearchResults<T = Record<string, any>>(
   meilisearchResults: MeilisearchMultiSearchResult[],
   initialFacetDistribution: Record<string, FacetDistribution>,
-  config: InstantMeiliSearchConfig
+  config: InstantMeilisearchConfig
 ): { results: Array<MeilisearchSearchResponse<T>> } {
   const instantSearchResult: Array<MeilisearchSearchResponse<T>> =
     meilisearchResults.map((meilisearchResult) => {
@@ -42,13 +42,13 @@ export function adaptSearchResults<T = Record<string, any>>(
  *
  * @param {MeilisearchMultiSearchResult<Record<string>>} searchResponse
  * @param {Record<string, FacetDistribution>} initialFacetDistribution
- * @param {InstantMeiliSearchConfig} config
+ * @param {InstantMeilisearchConfig} config
  * @returns {MeilisearchSearchResponse<T>}
  */
 export function adaptSearchResult<T>(
   meiliSearchResult: MeilisearchMultiSearchResult,
   initialFacetDistribution: FacetDistribution,
-  config: InstantMeiliSearchConfig
+  config: InstantMeilisearchConfig
 ): MeilisearchSearchResponse<T> {
   const {
     processingTimeMs,

--- a/packages/instant-meilisearch/src/cache/init-facets-distribution.ts
+++ b/packages/instant-meilisearch/src/cache/init-facets-distribution.ts
@@ -1,7 +1,7 @@
 import type {
   FacetDistribution,
   SearchContext,
-  MeiliSearchMultiSearchParams,
+  MeilisearchMultiSearchParams,
   MultiSearchResolver,
   MeilisearchMultiSearchResult,
 } from '../types/index.js'
@@ -10,7 +10,7 @@ import { removeDuplicate } from '../utils/index.js'
 
 export function getParametersWithoutFilters(
   searchContext: SearchContext
-): MeiliSearchMultiSearchParams {
+): MeilisearchMultiSearchParams {
   const defaultSearchContext = {
     ...searchContext,
     // placeholdersearch true to ensure a request is made
@@ -30,7 +30,7 @@ export function getParametersWithoutFilters(
 // Used to fill the missing facet values when `keepZeroFacets` is set to true
 export async function initFacetDistribution(
   searchResolver: MultiSearchResolver,
-  queries: MeiliSearchMultiSearchParams[],
+  queries: MeilisearchMultiSearchParams[],
   initialFacetDistribution: Record<string, FacetDistribution>
 ): Promise<Record<string, FacetDistribution>> {
   const removeIndexUidDuplicates = removeDuplicate('indexUid')

--- a/packages/instant-meilisearch/src/client/config/index.ts
+++ b/packages/instant-meilisearch/src/client/config/index.ts
@@ -1,6 +1,6 @@
 import type {
-  InstantMeiliSearchOptions,
-  InstantMeiliSearchConfig,
+  InstantMeilisearchOptions,
+  InstantMeilisearchConfig,
   ApiKeyCallback,
 } from '../../types/index.js'
 import { isPureObject } from '../../utils/object.js'
@@ -8,13 +8,13 @@ import { isPureObject } from '../../utils/object.js'
 /**
  * Get the configuration of instant meilisearch
  *
- * @param {InstantMeiliSearchOptions} option
- * @returns {InstantMeiliSearchConfig}
+ * @param {InstantMeilisearchOptions} option
+ * @returns {InstantMeilisearchConfig}
  */
 
 export function getInstantMeilisearchConfig(
-  options: InstantMeiliSearchOptions
-): InstantMeiliSearchConfig {
+  options: InstantMeilisearchOptions
+): InstantMeilisearchConfig {
   const defaultOptions = {
     placeholderSearch: true,
     keepZeroFacets: false,
@@ -56,12 +56,12 @@ export function getApiKey(apiKey: string | ApiKeyCallback): string {
  * @param hostUrl
  * @param apiKey
  */
-export function validateInstantMeiliSearchParams(
+export function validateInstantMeilisearchParams(
   hostUrl: string,
   apiKey: string | (() => string),
-  instantMeiliSearchOptions: InstantMeiliSearchOptions
+  instantMeilisearchOptions: InstantMeilisearchOptions
 ) {
-  const { requestInit, httpClient } = instantMeiliSearchOptions
+  const { requestInit, httpClient } = instantMeilisearchOptions
   // Validate host url
   if (typeof hostUrl !== 'string') {
     throw new TypeError(

--- a/packages/instant-meilisearch/src/client/instant-meilisearch-client.ts
+++ b/packages/instant-meilisearch/src/client/instant-meilisearch-client.ts
@@ -85,18 +85,18 @@ export function instantMeilisearch(
   )
 
   return {
-    meiliSearchInstance: meilisearchClient,
+    meilisearchInstance: meilisearchClient,
     setMeilisearchParams: (params): void => {
-      const { meiliSearchParams } = instantMeilisearchOptions
+      const { meilisearchParams } = instantMeilisearchOptions
 
-      instantMeilisearchOptions.meiliSearchParams =
-        meiliSearchParams === undefined
+      instantMeilisearchOptions.meilisearchParams =
+        meilisearchParams === undefined
           ? params
           : {
-              ...meiliSearchParams,
+              ...meilisearchParams,
               ...params,
               indexesOverrides: {
-                ...(meiliSearchParams.indexesOverrides || {}),
+                ...(meilisearchParams.indexesOverrides || {}),
                 ...(params.indexesOverrides || {}),
               },
             }

--- a/packages/instant-meilisearch/src/client/instant-meilisearch-client.ts
+++ b/packages/instant-meilisearch/src/client/instant-meilisearch-client.ts
@@ -1,6 +1,6 @@
-import { MeiliSearch } from 'meilisearch'
+import { Meilisearch } from 'meilisearch'
 import type {
-  InstantMeiliSearchOptions,
+  InstantMeilisearchOptions,
   AlgoliaMultipleQueriesQuery,
   SearchContext,
   FacetDistribution,
@@ -8,14 +8,14 @@ import type {
   MeilisearchConfig,
   AlgoliaSearchForFacetValuesRequests,
   AlgoliaSearchForFacetValuesResponse,
-  InstantMeiliSearchObject,
+  InstantMeilisearchObject,
   ApiKeyCallback,
   MeilisearchSearchResponse,
 } from '../types/index.js'
 import {
   getApiKey,
   getInstantMeilisearchConfig,
-  validateInstantMeiliSearchParams,
+  validateInstantMeilisearchParams,
 } from './config/index.js'
 import {
   adaptSearchResults,
@@ -39,23 +39,23 @@ import { constructClientAgents } from './agents.js'
  *
  * @param {string} hostUrl
  * @param {string | ApiKeyCallback} [apiKey=''] Default is `''`
- * @param {InstantMeiliSearchOptions} [instantMeiliSearchOptions={}] Default is
+ * @param {InstantMeilisearchOptions} [instantMeilisearchOptions={}] Default is
  *   `{}`
- * @returns {InstantMeiliSearchObject}
+ * @returns {InstantMeilisearchObject}
  */
-export function instantMeiliSearch(
+export function instantMeilisearch(
   hostUrl: string,
   apiKey: string | ApiKeyCallback = '',
-  instantMeiliSearchOptions: InstantMeiliSearchOptions = {}
-): InstantMeiliSearchObject {
+  instantMeilisearchOptions: InstantMeilisearchOptions = {}
+): InstantMeilisearchObject {
   // Validate parameters
-  validateInstantMeiliSearchParams(hostUrl, apiKey, instantMeiliSearchOptions)
+  validateInstantMeilisearchParams(hostUrl, apiKey, instantMeilisearchOptions)
 
   // Resolve possible function to get apiKey
   apiKey = getApiKey(apiKey)
 
   const clientAgents = constructClientAgents(
-    instantMeiliSearchOptions.clientAgents
+    instantMeilisearchOptions.clientAgents
   )
 
   const meilisearchConfig: MeilisearchConfig = {
@@ -64,15 +64,15 @@ export function instantMeiliSearch(
     clientAgents,
   }
 
-  if (instantMeiliSearchOptions.httpClient !== undefined) {
-    meilisearchConfig.httpClient = instantMeiliSearchOptions.httpClient
+  if (instantMeilisearchOptions.httpClient !== undefined) {
+    meilisearchConfig.httpClient = instantMeilisearchOptions.httpClient
   }
 
-  if (instantMeiliSearchOptions.requestInit !== undefined) {
-    meilisearchConfig.requestInit = instantMeiliSearchOptions.requestInit
+  if (instantMeilisearchOptions.requestInit !== undefined) {
+    meilisearchConfig.requestInit = instantMeilisearchOptions.requestInit
   }
 
-  const meilisearchClient = new MeiliSearch(meilisearchConfig)
+  const meilisearchClient = new Meilisearch(meilisearchConfig)
 
   const searchCache = SearchCache()
   // create search resolver with included cache
@@ -81,15 +81,15 @@ export function instantMeiliSearch(
   let initialFacetDistribution: Record<string, FacetDistribution> = {}
 
   const instantMeilisearchConfig = getInstantMeilisearchConfig(
-    instantMeiliSearchOptions
+    instantMeilisearchOptions
   )
 
   return {
     meiliSearchInstance: meilisearchClient,
-    setMeiliSearchParams: (params): void => {
-      const { meiliSearchParams } = instantMeiliSearchOptions
+    setMeilisearchParams: (params): void => {
+      const { meiliSearchParams } = instantMeilisearchOptions
 
-      instantMeiliSearchOptions.meiliSearchParams =
+      instantMeilisearchOptions.meiliSearchParams =
         meiliSearchParams === undefined
           ? params
           : {
@@ -118,7 +118,7 @@ export function instantMeiliSearch(
           for (const searchRequest of instantSearchRequests) {
             const searchContext: SearchContext = createSearchContext(
               searchRequest,
-              instantMeiliSearchOptions
+              instantMeilisearchOptions
             )
 
             // Adapt the search parameters provided by instantsearch to
@@ -173,7 +173,7 @@ export function instantMeiliSearch(
         for (const request of requests) {
           const searchContext: SearchContext = createFacetSearchContext(
             request,
-            instantMeiliSearchOptions
+            instantMeilisearchOptions
           )
 
           const meilisearchSearchQuery = adaptSearchParams(searchContext)

--- a/packages/instant-meilisearch/src/contexts/search-context.ts
+++ b/packages/instant-meilisearch/src/contexts/search-context.ts
@@ -1,5 +1,5 @@
 import type {
-  InstantMeiliSearchOptions,
+  InstantMeilisearchOptions,
   AlgoliaMultipleQueriesQuery,
   SearchContext,
   AlgoliaSearchForFacetValuesRequest,
@@ -31,7 +31,7 @@ function separateIndexFromSortRules(indexName: string): {
  */
 export function createSearchContext(
   searchRequest: AlgoliaMultipleQueriesQuery,
-  options: InstantMeiliSearchOptions
+  options: InstantMeilisearchOptions
 ): SearchContext {
   const { query, indexName, params: instantSearchParams } = searchRequest
   // Split index name and possible sorting rules
@@ -63,7 +63,7 @@ export function createSearchContext(
  */
 export function createFacetSearchContext(
   searchRequest: AlgoliaSearchForFacetValuesRequest,
-  options: InstantMeiliSearchOptions
+  options: InstantMeilisearchOptions
 ): SearchContext {
   // Split index name and possible sorting rules
   const { indexUid, sortBy } = separateIndexFromSortRules(

--- a/packages/instant-meilisearch/src/types/types.ts
+++ b/packages/instant-meilisearch/src/types/types.ts
@@ -4,10 +4,10 @@ import type {
 } from '@algolia/client-search'
 import type { InstantSearchOptions } from 'instantsearch.js/es/lib/InstantSearch.js'
 import type {
-  MultiSearchQuery as MeiliSearchMultiSearchParams,
+  MultiSearchQuery as MeilisearchMultiSearchParams,
   MultiSearchResult,
   Config as MeilisearchConfig,
-  MeiliSearch,
+  Meilisearch,
 } from 'meilisearch'
 
 // Turns readonly types into mutable ones
@@ -29,9 +29,9 @@ export type AlgoliaSearchForFacetValuesRequest =
 export type {
   Filter,
   FacetDistribution,
-  MeiliSearch,
+  Meilisearch,
   FacetStats as MeiliFacetStats,
-  MultiSearchQuery as MeiliSearchMultiSearchParams,
+  MultiSearchQuery as MeilisearchMultiSearchParams,
   Config as MeilisearchConfig,
 } from 'meilisearch'
 
@@ -41,8 +41,8 @@ export type InstantSearchParams = NonNullable<
   AlgoliaMultipleQueriesQuery['params']
 >
 
-type BaseOverridableMeiliSearchSearchParameters = Pick<
-  MeiliSearchMultiSearchParams,
+type BaseOverridableMeilisearchSearchParameters = Pick<
+  MeilisearchMultiSearchParams,
   | 'sort'
   | 'hitsPerPage'
   | 'filter'
@@ -64,36 +64,36 @@ type BaseOverridableMeiliSearchSearchParameters = Pick<
   | 'vector'
 >
 
-export type OverridableMeiliSearchSearchParameters =
-  BaseOverridableMeiliSearchSearchParameters & {
+export type OverridableMeilisearchSearchParameters =
+  BaseOverridableMeilisearchSearchParameters & {
     indexesOverrides?: Record<
       string,
-      BaseOverridableMeiliSearchSearchParameters
+      BaseOverridableMeilisearchSearchParameters
     >
   }
 
-type BaseInstantMeiliSearchOptions = {
+type BaseInstantMeilisearchOptions = {
   placeholderSearch?: boolean
   primaryKey?: string
   keepZeroFacets?: boolean
   clientAgents?: string[]
   finitePagination?: boolean
-  meiliSearchParams?: OverridableMeiliSearchSearchParameters
+  meiliSearchParams?: OverridableMeilisearchSearchParameters
 }
 
-export type InstantMeiliSearchOptions = Pick<
+export type InstantMeilisearchOptions = Pick<
   MeilisearchConfig,
   'requestInit' | 'httpClient'
 > &
-  BaseInstantMeiliSearchOptions
+  BaseInstantMeilisearchOptions
 
-export type InstantMeiliSearchConfig = Required<
+export type InstantMeilisearchConfig = Required<
   Pick<
-    InstantMeiliSearchOptions,
+    InstantMeilisearchOptions,
     'placeholderSearch' | 'keepZeroFacets' | 'clientAgents' | 'finitePagination'
   >
 > &
-  BaseInstantMeiliSearchOptions
+  BaseInstantMeilisearchOptions
 
 export type SearchCacheInterface = {
   getEntry: <T>(key: string) => T | undefined
@@ -140,7 +140,7 @@ export type MeilisearchSearchResponse<T = Record<string, any>> = Omit<
   }
 }
 
-export type SearchContext = InstantMeiliSearchOptions &
+export type SearchContext = InstantMeilisearchOptions &
   InstantSearchParams & {
     pagination: PaginationState
     indexUid: string
@@ -157,20 +157,20 @@ export type InstantSearchGeoParams = {
   insidePolygon?: ReadonlyArray<readonly number[]>
 }
 
-export type InstantMeiliSearchInstance =
+export type InstantMeilisearchInstance =
   InstantSearchOptions['searchClient'] & {
     clearCache: () => void
   }
 
-export type InstantMeiliSearchObject = {
-  meiliSearchInstance: MeiliSearch
-  setMeiliSearchParams: (params: OverridableMeiliSearchSearchParameters) => void
-  searchClient: InstantMeiliSearchInstance
+export type InstantMeilisearchObject = {
+  meiliSearchInstance: Meilisearch
+  setMeilisearchParams: (params: OverridableMeilisearchSearchParameters) => void
+  searchClient: InstantMeilisearchInstance
 }
 
 export type MultiSearchResolver = {
   multiSearch: (
-    searchQueries: MeiliSearchMultiSearchParams[],
+    searchQueries: MeilisearchMultiSearchParams[],
     instantSearchPagination: PaginationState[]
   ) => Promise<MeilisearchMultiSearchResult[]>
 }

--- a/packages/instant-meilisearch/src/types/types.ts
+++ b/packages/instant-meilisearch/src/types/types.ts
@@ -78,7 +78,7 @@ type BaseInstantMeilisearchOptions = {
   keepZeroFacets?: boolean
   clientAgents?: string[]
   finitePagination?: boolean
-  meiliSearchParams?: OverridableMeilisearchSearchParameters
+  meilisearchParams?: OverridableMeilisearchSearchParameters
 }
 
 export type InstantMeilisearchOptions = Pick<
@@ -163,7 +163,7 @@ export type InstantMeilisearchInstance =
   }
 
 export type InstantMeilisearchObject = {
-  meiliSearchInstance: Meilisearch
+  meilisearchInstance: Meilisearch
   setMeilisearchParams: (params: OverridableMeilisearchSearchParameters) => void
   searchClient: InstantMeilisearchInstance
 }

--- a/playgrounds/autocomplete/setup.mjs
+++ b/playgrounds/autocomplete/setup.mjs
@@ -1,7 +1,7 @@
 import { meilisearch } from '@meilisearch/instant-meilisearch'
 import games from './assets/games.json' with { type: 'json' }
 
-const client = new meilisearch.MeiliSearch({
+const client = new meilisearch.Meilisearch({
   host: 'http://localhost:7700',
   apiKey: 'masterKey',
 })

--- a/playgrounds/javascript/src/app.js
+++ b/playgrounds/javascript/src/app.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-undef */
-import { instantMeiliSearch } from '@meilisearch/instant-meilisearch'
+import { instantMeilisearch } from '@meilisearch/instant-meilisearch'
 
 const search = instantsearch({
   indexName: 'steam-video-games',
-  searchClient: instantMeiliSearch(
+  searchClient: instantMeilisearch(
     'https://ms-adf78ae33284-106.lon.meilisearch.io',
     'a63da4928426f12639e19d62886f621130f3fa9ff3c7534c5d179f0f51c4f303',
     {

--- a/playgrounds/local-react/setup.mjs
+++ b/playgrounds/local-react/setup.mjs
@@ -2,7 +2,7 @@ import { meilisearch } from '@meilisearch/instant-meilisearch'
 import movies from './assets/movies.json' with { type: 'json' }
 import games from './assets/games.json' with { type: 'json' }
 
-const client = new meilisearch.MeiliSearch({
+const client = new meilisearch.Meilisearch({
   host: 'http://127.0.0.1:7700',
   apiKey: 'masterKey',
 })

--- a/playgrounds/local-react/src/components/MultiIndex.jsx
+++ b/playgrounds/local-react/src/components/MultiIndex.jsx
@@ -9,9 +9,9 @@ import {
   Pagination,
   Hits,
 } from 'react-instantsearch'
-import { instantMeiliSearch } from '@meilisearch/instant-meilisearch'
+import { instantMeilisearch } from '@meilisearch/instant-meilisearch'
 
-const { searchClient } = instantMeiliSearch(
+const { searchClient } = instantMeilisearch(
   'http://localhost:7700',
   'masterKey',
   {

--- a/playgrounds/local-react/src/components/SingleIndex.jsx
+++ b/playgrounds/local-react/src/components/SingleIndex.jsx
@@ -11,9 +11,9 @@ import {
   SortBy,
   Snippet,
 } from 'react-instantsearch'
-import { instantMeiliSearch } from '@meilisearch/instant-meilisearch'
+import { instantMeilisearch } from '@meilisearch/instant-meilisearch'
 
-const { searchClient } = instantMeiliSearch(
+const { searchClient } = instantMeilisearch(
   'http://localhost:7700',
   'masterKey',
   { primaryKey: 'id' }

--- a/playgrounds/local-react/src/components/SingleMovieIndex.jsx
+++ b/playgrounds/local-react/src/components/SingleMovieIndex.jsx
@@ -8,9 +8,9 @@ import {
   ClearRefinements,
   RefinementList,
 } from 'react-instantsearch'
-import { instantMeiliSearch } from '@meilisearch/instant-meilisearch'
+import { instantMeilisearch } from '@meilisearch/instant-meilisearch'
 
-const { searchClient } = instantMeiliSearch(
+const { searchClient } = instantMeilisearch(
   'http://localhost:7700',
   'masterKey',
   { primaryKey: 'id', keepZeroFacets: true }

--- a/playgrounds/node-env/index.js
+++ b/playgrounds/node-env/index.js
@@ -1,14 +1,14 @@
 import {
-  instantMeiliSearch,
+  instantMeilisearch,
   meilisearch,
 } from '@meilisearch/instant-meilisearch'
 
-const { searchClient } = instantMeiliSearch(
+const { searchClient } = instantMeilisearch(
   'http://localhost:7700',
   'masterKey',
   {}
 )
-const msClient = new meilisearch.MeiliSearch({
+const msClient = new meilisearch.Meilisearch({
   host: 'http://localhost:7700',
   apiKey: 'masterKey',
 })

--- a/playgrounds/react/src/App.jsx
+++ b/playgrounds/react/src/App.jsx
@@ -13,9 +13,9 @@ import {
 } from 'react-instantsearch'
 
 import './App.css'
-import { instantMeiliSearch } from '@meilisearch/instant-meilisearch'
+import { instantMeilisearch } from '@meilisearch/instant-meilisearch'
 
-const { searchClient } = instantMeiliSearch(
+const { searchClient } = instantMeilisearch(
   'https://ms-adf78ae33284-106.lon.meilisearch.io',
   'a63da4928426f12639e19d62886f621130f3fa9ff3c7534c5d179f0f51c4f303',
   {

--- a/playgrounds/vue3/src/App.vue
+++ b/playgrounds/vue3/src/App.vue
@@ -1,12 +1,12 @@
 <template>
   <div>
     <header class="header">
-      <h1 class="header-title">MeiliSearch + Vue 3 InstantSearch</h1>
+      <h1 class="header-title">Meilisearch + Vue 3 InstantSearch</h1>
       <p class="header-subtitle">Search in Steam video games 🎮</p>
     </header>
     <p class="disclaimer">
       This is not the official Steam dataset but only for demo purpose. Enjoy
-      searching with MeiliSearch!
+      searching with Meilisearch!
     </p>
     <div class="container">
       <ais-instant-search
@@ -52,12 +52,12 @@
 </template>
 
 <script>
-import { instantMeiliSearch } from '@meilisearch/instant-meilisearch'
+import { instantMeilisearch } from '@meilisearch/instant-meilisearch'
 
 export default {
   data() {
     return {
-      searchClient: instantMeiliSearch(
+      searchClient: instantMeilisearch(
         'https://ms-adf78ae33284-106.lon.meilisearch.io',
         'a63da4928426f12639e19d62886f621130f3fa9ff3c7534c5d179f0f51c4f303',
         {


### PR DESCRIPTION
# Pull Request

## What does this PR do?
- Following https://github.com/meilisearch/meilisearch-js/pull/2144 rename every uppercase "S" in "\*MeiliSearch\*" to lower case "s"

## Migration

```diff
- import { instantMeiliSearch } from "@meilisearch/instant-meilisearch";
+ import { instantMeilisearch } from "@meilisearch/instant-meilisearch";
// ... same pattern for every other export
```

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Rebranded API and public types to use "Meilisearch" casing (instantMeilisearch and related identifiers) for consistent naming across the public surface.

* **Documentation**
  * Updated README examples and migration guidance to reflect the new naming and option keys.

* **Chores**
  * Bumped declared package manager version in workspace metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->